### PR TITLE
Fedora 26, CentOS 7 Support: Added checks for lsb_release program and renamed variables

### DIFF
--- a/curl-me
+++ b/curl-me
@@ -4,7 +4,13 @@
 set -e
 # "set -e" to exit on error (avoids snowballing)
 
-LSB_RELEASE=`which lsb_release`
+# Checks if lsb_release is available on the system
+if [-x lsb_release]; then
+        LSB_RELEASE=`which lsb_release`
+else
+        echo "The 'lsb_release' program is missing."
+fi
+
 
 if [ "$LSB_RELEASEx" != "x" ]; then
   LINUX_DIST=`lsb_release -is`
@@ -13,17 +19,21 @@ else
     # assume Raspbian has lsb_release
     LINUX_DIST = "Debian"
   elif [ -f /etc/centos_version ]; then
-    LINUX_DIST = "Centos"
+    LINUX_DIST = "CentOS"
+  elif [ -f /etc/redhat-release ]; then
+    LINUX_DIST = "Fedora"
   else
     LINUX_DIST = "Unknown"
   fi
 fi
 
-if [ $LINUX_DIST == "Centos" ]; then
+if [ $LINUX_DIST == "CentOS" ]; then
   yum update
   # in case needed
   yum install -y git
-
+elif [ $LINUX_DIST == "Fedora" ]; then
+  dnf -y update
+  dnf -y install git
 elif [ $LINUX_DIST == "Ubuntu" ] || [ $LINUX_DIST == "Debian" ] || [ $LINUX_DIST == "Raspbian" ]; then
   export DEBIAN_FRONTEND=noninteractive
   apt-get -y update


### PR DESCRIPTION
Tested this script in CentOS 7. 

Added checks to see if lsb_release is available on the system. 

Changed variable from 'Centos' to 'CentOS'.