### PR TITLE
IMAGER docs cleanup

### DIFF
--- a/box/rpi/imager/docs/README.html
+++ b/box/rpi/imager/docs/README.html
@@ -10,12 +10,18 @@
 <body>
 <h2 id="how-to-get-started----create-imager-on-a-usb-stick">How to Get Started -- Create IMAGER on a USB Stick</h2>
 <ul>
-<li>Download the most recent IMAGER from http://download.iiab.io/packages/imager/. Depending on the speed of your internet, this could take a while (about 112MB).</li>
-<li>Use https://etcher.io or https://sourceforge.net/projects/win32diskimager/ to write the downloaded image file to a USB stick (all data will be lost)</li>
-<li>Make sure that your BIOS is set to boot first from USB -- setting the BIOS may require that you strike the F1, F2, F10, F12, or Delete key just after turning on the power.</li>
-<li>Look for a BIOS setting called &quot;boot options&quot; or &quot;boot order&quot;, and make sure that USB disk comes first.</li>
-<li>Put the USB stick into the machine, and turn on the power.</li>
-<li>After a short time you should see the colorful boot process of Tiny Core Linux, and eventually the IMAGER menu as shown at https://github.com/iiab/iiab-factory/blob/master/box/rpi/imager/docs/README.md</li>
+<li>IMAGER makes it easy to back up, shrink (truncate) and copy Internet-in-a-Box microSD cards, on almost any Windows computer.</li>
+<li>Amazingly, IMAGER even allows you to copy to microSD cards that are &quot;just a bit too small&quot; (when extremely annoying size differences between manufacturers prevent other copying tools from working!)</li>
+<li>In future Mac computers may be supported as well.</li>
+<li>On the Linux OS, please use the <a href="https://www.linuxnix.com/what-you-should-know-about-linux-dd-command/">dd</a> and <a href="https://github.com/iiab/iiab-factory/blob/master/box/rpi/howto-mkimg.txt">min-sd and cp-sd</a> commands (min-sd is the underlying magic that shrinks or truncates microSD cards, without any data loss).</li>
+<li>DOWNLOAD the most recent IMAGER from <a href="http://download.iiab.io/packages/imager/">download.iiab.io/packages/imager</a>. Depending on the speed of your Internet, this could take a while (IMAGER is about 112 MB).</li>
+<li>Use <a href="https://etcher.io">Etcher.io</a> or <a href="https://sourceforge.net/projects/win32diskimager/">sourceforge.net/projects/win32diskimager</a> to flash (burn) the downloaded .img file onto a USB stick — all USB stick data will be lost!</li>
+<li>Make sure that your Windows computer's BIOS is set to boot first from USB.</li>
+<li>Setting the BIOS may require that you strike the F1, F2, F10, F12, or Delete key just after turning on the power.</li>
+<li>Look for a BIOS setting called &quot;boot options&quot; or &quot;boot order&quot;, and make sure the USB drive (USB stick) comes first.</li>
+<li>Put the USB stick into your Windows computer, and turn on the power.</li>
+<li>After a short time you should see the colorful boot process of Tiny Core Linux, and eventually the IMAGER menu as shown in IMAGER's <a href="https://github.com/iiab/iiab-factory/blob/master/box/rpi/imager/docs/GET-STARTED-GUIDE.md">GET STARTED GUIDE</a>.</li>
+<li>Begin copying Internet-in-a-Box microSD cards!</li>
 </ul>
 </body>
 </html>

--- a/box/rpi/imager/docs/README.md
+++ b/box/rpi/imager/docs/README.md
@@ -1,5 +1,5 @@
 ## How to Get Started -- Create IMAGER on a USB Stick
-* IMAGER makes it easy to backup, shrink (truncate) and copy Internet-in-a-Box microSD cards, on almost any Windows computer.
+* IMAGER makes it easy to back up, shrink (truncate) and copy Internet-in-a-Box microSD cards, on almost any Windows computer.
   * Amazingly, IMAGER even allows you to copy to microSD cards that are "just a bit too small" when extremely annoying size differences between manufacturers prevent other copying tools from working!
   * In future Mac computers may be supported as well.
   * On the Linux OS, please use the [dd](https://www.linuxnix.com/what-you-should-know-about-linux-dd-command/) and [min-sd and cp-sd](https://github.com/iiab/iiab-factory/blob/master/box/rpi/howto-mkimg.txt) commands (min-sd is the underlying magic that shrinks or truncates microSD cards, without any loss of data).

--- a/box/rpi/imager/docs/README.md
+++ b/box/rpi/imager/docs/README.md
@@ -1,7 +1,11 @@
 ## How to Get Started -- Create IMAGER on a USB Stick
-* Download the most recent IMAGER from http://download.iiab.io/packages/imager/. Depending on the speed of your internet, this could take a while (about 112MB).
-* Use https://etcher.io or https://sourceforge.net/projects/win32diskimager/ to write the downloaded image file to a USB stick (all data will be lost)
-* Make sure that your BIOS is set to boot first from USB -- setting the BIOS may require that you strike the F1, F2, F10, F12, or Delete key just after turning on the power.
-* Look for a BIOS setting called "boot options" or "boot order", and make sure that USB disk comes first.
-* Put the USB stick into the machine, and turn on the power.
-* After a short time you should see the colorful boot process of Tiny Core Linux, and eventually the IMAGER menu as shown at https://github.com/iiab/iiab-factory/blob/master/box/rpi/imager/docs/README.md
+* IMAGER makes it easy to backup, shrink (truncate) and copy Internet-in-a-Box microSD cards, on almost any Windows computer.
+  * Amazingly, IMAGER even allows you to copy to microSD cards that are "just a bit too small" when extremely annoying size differences between manufacturers prevent other copying tools from working!
+  * In future Mac computers may be supported as well.
+  * On the Linux OS, please use the [dd](https://www.linuxnix.com/what-you-should-know-about-linux-dd-command/) and [min-sd and cp-sd](https://github.com/iiab/iiab-factory/blob/master/box/rpi/howto-mkimg.txt) commands (min-sd is the underlying magic that shrinks or truncates microSD cards, without any loss of data).
+* Download the most recent IMAGER from [download.iiab.io/packages/imager](http://download.iiab.io/packages/imager/).  Depending on the speed of your Internet, this could take a while (IMAGER is about 112 MB).
+* Use [Etcher.io](https://etcher.io) or [sourceforge.net/projects/win32diskimager](https://sourceforge.net/projects/win32diskimager/) to write the downloaded .img file to a USB stick (all the stick's data will be lost!)
+* Make sure that your Windows computer's BIOS is set to boot first from USB &mdash; setting the BIOS may require that you strike the F1, F2, F10, F12, or Delete key just after turning on the power.
+* Look for a BIOS setting called "boot options" or "boot order", and make sure the USB drive (USB stick) comes first.
+* Put the USB stick into your Windows computer, and turn on the power.
+* After a short time you should see the colorful boot process of Tiny Core Linux, and eventually the IMAGER menu as shown in IMAGER's [GET STARTED GUIDE](https://github.com/iiab/iiab-factory/blob/master/box/rpi/imager/docs/GET-STARTED-GUIDE.md).

--- a/box/rpi/imager/docs/README.md
+++ b/box/rpi/imager/docs/README.md
@@ -3,8 +3,8 @@
   * Amazingly, IMAGER even allows you to copy to microSD cards that are "just a bit too small" (when extremely annoying size differences between manufacturers prevent other copying tools from working!)
   * In future Mac computers may be supported as well.
   * On the Linux OS, please use the [dd](https://www.linuxnix.com/what-you-should-know-about-linux-dd-command/) and [min-sd and cp-sd](https://github.com/iiab/iiab-factory/blob/master/box/rpi/howto-mkimg.txt) commands (min-sd is the underlying magic that shrinks or truncates microSD cards, without any data loss).
-* Download the most recent IMAGER from [download.iiab.io/packages/imager](http://download.iiab.io/packages/imager/).  Depending on the speed of your Internet, this could take a while (IMAGER is about 112 MB).
-* Use [Etcher.io](https://etcher.io) or [sourceforge.net/projects/win32diskimager](https://sourceforge.net/projects/win32diskimager/) to burn or flash the downloaded .img file onto a USB stick (all USB stick data will be lost!)
+* DOWNLOAD the most recent IMAGER from [download.iiab.io/packages/imager](http://download.iiab.io/packages/imager/).  Depending on the speed of your Internet, this could take a while (IMAGER is about 112 MB).
+* Use [Etcher.io](https://etcher.io) or [sourceforge.net/projects/win32diskimager](https://sourceforge.net/projects/win32diskimager/) to flash (burn) the downloaded .img file onto a USB stick &mdash; all USB stick data will be lost!
 * Make sure that your Windows computer's BIOS is set to boot first from USB.
   * Setting the BIOS may require that you strike the F1, F2, F10, F12, or Delete key just after turning on the power.
   * Look for a BIOS setting called "boot options" or "boot order", and make sure the USB drive (USB stick) comes first.

--- a/box/rpi/imager/docs/README.md
+++ b/box/rpi/imager/docs/README.md
@@ -1,11 +1,13 @@
 ## How to Get Started -- Create IMAGER on a USB Stick
 * IMAGER makes it easy to back up, shrink (truncate) and copy Internet-in-a-Box microSD cards, on almost any Windows computer.
-  * Amazingly, IMAGER even allows you to copy to microSD cards that are "just a bit too small" when extremely annoying size differences between manufacturers prevent other copying tools from working!
+  * Amazingly, IMAGER even allows you to copy to microSD cards that are "just a bit too small" (when extremely annoying size differences between manufacturers prevent other copying tools from working!)
   * In future Mac computers may be supported as well.
-  * On the Linux OS, please use the [dd](https://www.linuxnix.com/what-you-should-know-about-linux-dd-command/) and [min-sd and cp-sd](https://github.com/iiab/iiab-factory/blob/master/box/rpi/howto-mkimg.txt) commands (min-sd is the underlying magic that shrinks or truncates microSD cards, without any loss of data).
+  * On the Linux OS, please use the [dd](https://www.linuxnix.com/what-you-should-know-about-linux-dd-command/) and [min-sd and cp-sd](https://github.com/iiab/iiab-factory/blob/master/box/rpi/howto-mkimg.txt) commands (min-sd is the underlying magic that shrinks or truncates microSD cards, without any data loss).
 * Download the most recent IMAGER from [download.iiab.io/packages/imager](http://download.iiab.io/packages/imager/).  Depending on the speed of your Internet, this could take a while (IMAGER is about 112 MB).
-* Use [Etcher.io](https://etcher.io) or [sourceforge.net/projects/win32diskimager](https://sourceforge.net/projects/win32diskimager/) to write the downloaded .img file to a USB stick (all the stick's data will be lost!)
-* Make sure that your Windows computer's BIOS is set to boot first from USB &mdash; setting the BIOS may require that you strike the F1, F2, F10, F12, or Delete key just after turning on the power.
-* Look for a BIOS setting called "boot options" or "boot order", and make sure the USB drive (USB stick) comes first.
+* Use [Etcher.io](https://etcher.io) or [sourceforge.net/projects/win32diskimager](https://sourceforge.net/projects/win32diskimager/) to burn or flash the downloaded .img file onto a USB stick (all USB stick data will be lost!)
+* Make sure that your Windows computer's BIOS is set to boot first from USB.
+  * Setting the BIOS may require that you strike the F1, F2, F10, F12, or Delete key just after turning on the power.
+  * Look for a BIOS setting called "boot options" or "boot order", and make sure the USB drive (USB stick) comes first.
 * Put the USB stick into your Windows computer, and turn on the power.
-* After a short time you should see the colorful boot process of Tiny Core Linux, and eventually the IMAGER menu as shown in IMAGER's [GET STARTED GUIDE](https://github.com/iiab/iiab-factory/blob/master/box/rpi/imager/docs/GET-STARTED-GUIDE.md).
+  * After a short time you should see the colorful boot process of Tiny Core Linux, and eventually the IMAGER menu as shown in IMAGER's [GET STARTED GUIDE](https://github.com/iiab/iiab-factory/blob/master/box/rpi/imager/docs/GET-STARTED-GUIDE.md).
+  * Begin copying Internet-in-a-Box microSD cards!

--- a/box/rpi/imager/docs2html
+++ b/box/rpi/imager/docs2html
@@ -10,5 +10,8 @@ else
    pandoc -s $IPATH/GET-STARTED-GUIDE.md -o $IPATH/GET-STARTED-GUIDE.html
 fi
 
-# 2018-09-08: both README.html and GET-STARTED-GUIDE.html will be published to:
+# README.html is published regularly to our download site:
 # http://download.iiab.io/packages/imager/
+
+# GET-STARTED-GUIDE.* can be viewed in the IMAGER app, and also online here:
+# https://github.com/iiab/iiab-factory/blob/master/box/rpi/imager/docs/README.md


### PR DESCRIPTION
Cleanup of unclickable + broken link within the new:
http://download.iiab.io/packages/imager/README.html

As sourced from:
https://github.com/iiab/iiab-factory/blob/master/box/rpi/imager/docs/GET-STARTED-GUIDE.md
https://github.com/iiab/iiab-factory/blob/master/box/rpi/imager/docs/GET-STARTED-GUIDE.html

Doc Workflow clarified within:
https://github.com/iiab/iiab-factory/blob/master/box/rpi/imager/docs2html

Builds on #47