### PR TITLE
IMAGER Docs refined with pandoc 2.2.3.2 (instead of 1.16-to-1.19)

### DIFF
--- a/box/rpi/imager/docs/GET-STARTED-GUIDE.html
+++ b/box/rpi/imager/docs/GET-STARTED-GUIDE.html
@@ -1,14 +1,22 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="" xml:lang="">
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
+  <meta charset="utf-8" />
   <meta name="generator" content="pandoc" />
-  <title></title>
-  <style type="text/css">code{white-space: pre;}</style>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
+  <title>GET-STARTED-GUIDE</title>
+  <style type="text/css">
+      code{white-space: pre-wrap;}
+      span.smallcaps{font-variant: small-caps;}
+      span.underline{text-decoration: underline;}
+      div.column{display: inline-block; vertical-align: top; width: 50%;}
+  </style>
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
-<h3 id="imager----duplicate-and-resize-sd-cards">IMAGER -- Duplicate and Resize SD Cards</h3>
+<h3 id="imager-duplicate-and-resize-sd-cards">IMAGER – Duplicate and Resize SD Cards</h3>
 <ul>
 <li>Completely menu-driven</li>
 <li>Boots on older Windows machines (MBR boot) as well as newer UEFI bios loaders.</li>
@@ -31,84 +39,75 @@
 <li>Enter acts on the currently displayed selection with the displayed action</li>
 <li>Backspace erases on the fill-in-the-blank screen. (tab cycles between fields, and actions at bottom.</li>
 </ul>
-<div class="figure">
-<img src="menu.png" alt="Main Menu Options" />
-<p class="caption">Main Menu Options</p>
-</div>
+<figure>
+<img src="menu.png" alt="Main Menu Options" /><figcaption>Main Menu Options</figcaption>
+</figure>
 <ul>
 <li>Use great care to keep track of which SD card is which. Whenever I remove a microSD from a Raspberry Pi, I place it in a standard-size carrier, and put a label on the contact side.</li>
 <li>You do not want to accidentally copy the contents of an older SD card onto the one which has the most recent updates.</li>
-<li>There is a file inside of each IIAB image which has much information. Use the &quot;&lt; info &gt;&quot; tab (middle bottom) if ever you are unsure about the identity of an SD card.</li>
+<li>There is a file inside of each IIAB image which has much information. Use the “&lt; info &gt;” tab (middle bottom) if ever you are unsure about the identity of an SD card.</li>
 </ul>
-<h4 id="copy2sd----copy-to-sd-card-destroys-all-data-on-target">Copy2SD -- Copy to SD Card (DESTROYS ALL DATA ON TARGET)</h4>
-<div class="figure">
-<img src="selectSource.png" alt="Choose Source" />
-<p class="caption">Choose Source</p>
-</div>
+<h4 id="copy2sd-copy-to-sd-card-destroys-all-data-on-target">Copy2SD – Copy to SD Card (DESTROYS ALL DATA ON TARGET)</h4>
+<figure>
+<img src="selectSource.png" alt="Choose Source" /><figcaption>Choose Source</figcaption>
+</figure>
 <ul>
 <li>The runtime-date and the install-date values may help sort out any confusion.</li>
 </ul>
-<div class="figure">
-<img src="ini.png" alt="Image Information" />
-<p class="caption">Image Information</p>
-</div>
+<figure>
+<img src="ini.png" alt="Image Information" /><figcaption>Image Information</figcaption>
+</figure>
 <ul>
 <li>On a Windows laptop with an internal SD slot, the SD device will probably start with mmcblk0.</li>
 <li>SD card adapters will have sdc, sdd, sde names.</li>
 </ul>
-<div class="figure">
-<img src="nofit.png" alt="Does it Fit?" />
-<p class="caption">Does it Fit?</p>
-</div>
+<figure>
+<img src="nofit.png" alt="Does it Fit?" /><figcaption>Does it Fit?</figcaption>
+</figure>
 <ul>
-<li>The internal hard disk on a Windows laptop will probably start with &quot;sda&quot;.</li>
+<li>The internal hard disk on a Windows laptop will probably start with “sda”.</li>
 <li>Copying from mmcblk0 to sdc is the shortest path, and quickest way to obtain a copy.</li>
 </ul>
-<div class="figure">
-<img src="choose_device.png" alt="Choose SD card as Destination" />
-<p class="caption">Choose SD card as Destination</p>
-</div>
-<h4 id="copy2disk----copy-to-hard-disk">Copy2disk -- Copy to Hard Disk</h4>
+<figure>
+<img src="choose_device.png" alt="Choose SD card as Destination" /><figcaption>Choose SD card as Destination</figcaption>
+</figure>
+<h4 id="copy2disk-copy-to-hard-disk">Copy2disk – Copy to Hard Disk</h4>
 <ul>
-<li>Sometimes the destination SD card is slightly smaller than the source, and the only way to make a successul copy is to first make a copy onto the hard disk, make that image smaller, and then copy the smaller version onto the new SD. (This is less error-prone, if you use a SD USB adapter -- though if you are careful, you can remove the source, and copy from the hard disk image, to the mmcblk slot which you earlier used as the source.)</li>
-<li>The &quot;smaller&quot;, &quot;image2sd&quot;, and &quot;delete&quot; commands use as default the hard drive chosen by this command. So if you want to change the default, use this command, and cancel out after choosing the hard disk device.</li>
+<li>Sometimes the destination SD card is slightly smaller than the source, and the only way to make a successul copy is to first make a copy onto the hard disk, make that image smaller, and then copy the smaller version onto the new SD. (This is less error-prone, if you use a SD USB adapter – though if you are careful, you can remove the source, and copy from the hard disk image, to the mmcblk slot which you earlier used as the source.)</li>
+<li>The “smaller”, “image2sd”, and “delete” commands use as default the hard drive chosen by this command. So if you want to change the default, use this command, and cancel out after choosing the hard disk device.</li>
 </ul>
-<h4 id="smaller----reduce-the-size-of-the-hard-disk-image">Smaller -- Reduce the Size of the Hard Disk Image</h4>
-<div class="figure">
-<img src="minify.png" alt="Make Image Smaller" />
-<p class="caption">Make Image Smaller</p>
-</div>
+<h4 id="smaller-reduce-the-size-of-the-hard-disk-image">Smaller – Reduce the Size of the Hard Disk Image</h4>
+<figure>
+<img src="minify.png" alt="Make Image Smaller" /><figcaption>Make Image Smaller</figcaption>
+</figure>
 <ul>
 <li>Confirm that the reduced image size is the desired operation.</li>
 </ul>
-<div class="figure">
-<img src="min.png" alt="Confirm resize operation" />
-<p class="caption">Confirm resize operation</p>
-</div>
+<figure>
+<img src="min.png" alt="Confirm resize operation" /><figcaption>Confirm resize operation</figcaption>
+</figure>
 <h4 id="hdisk2sd">hdisk2sd</h4>
 <ul>
 <li>After the image is written to the laptop hard disk, optionally reduced in size, it can be written to a destination SD card.</li>
 </ul>
-<div class="figure">
-<img src="img2sd.png" alt="Write image to SD" />
-<p class="caption">Write image to SD</p>
-</div>
+<figure>
+<img src="img2sd.png" alt="Write image to SD" /><figcaption>Write image to SD</figcaption>
+</figure>
 <ul>
 <li>Imager is written to enable the SD reader which is often available on laptops. MicroSD cards are usually purchased along with a standard sized SD carrier/adapter (on the left in the next image).</li>
-<li>I discovered that when I wrote to the SD card holder on my laptop using the carrier (identified as an mmcblk0 device) the speed was 2.7MB per second. Writing to the same card in a USB adapter (shown below -- the right two devices), the speed was 13.4MB/s. So there may be some motivation to use the USB adapters.</li>
+<li>I discovered that when I wrote to the SD card holder on my laptop using the carrier (identified as an mmcblk0 device) the speed was 2.7MB per second. Writing to the same card in a USB adapter (shown below – the right two devices), the speed was 13.4MB/s. So there may be some motivation to use the USB adapters.</li>
 </ul>
-<div class="figure">
-<img src="adapter_choice.jpg" alt="USB SD card Adapters" />
-<p class="caption">USB SD card Adapters</p>
-</div>
+<figure>
+<img src="adapter_choice.jpg" alt="USB SD card Adapters" /><figcaption>USB SD card Adapters</figcaption>
+</figure>
 <h4 id="exit-to-command-line-terminal">Exit to Command Line Terminal</h4>
 <ul>
 <li>This option brings up a informational screen which explains how to enable debugging and remote developer access. <img src="terminal.png" alt="Terminal and debugging information" /></li>
 <li>Debugging Imager, in all the different Windows machines that might be encountered, is a difficult task.</li>
-<li>VPN (virtual private networks) can be enabled (default=off) so that the developer can diagnose problems encountered by early adopters. This is achieved by exiting from the default (at boot time) Menu, and then typing &quot;imager&quot; at the terminal command line (to display a terminal, click on the icon of a terminal at bottom right of the screen).</li>
+<li>VPN (virtual private networks) can be enabled (default=off) so that the developer can diagnose problems encountered by early adopters. This is achieved by exiting from the default (at boot time) Menu, and then typing “imager” at the terminal command line (to display a terminal, click on the icon of a terminal at bottom right of the screen).</li>
 <li>VPN access to Imager normally only lasts until the next reboot.</li>
-<li>VPN access can be made to survive reboots by typing &quot;sudo filetool.sh -b&quot;, after starting IMAGER from the command line.</li>
-<li>Verify that the VPN is actually working by looking for the &quot;tun0&quot; response to &quot;sudo ip a&quot; terminal command.</li>
+<li>VPN access can be made to survive reboots by typing “sudo filetool.sh -b”, after starting IMAGER from the command line.</li>
+<li>Verify that the VPN is actually working by looking for the “tun0” response to “sudo ip a” terminal command.</li>
 </ul>
 </body>
 </html>

--- a/box/rpi/imager/docs/README.html
+++ b/box/rpi/imager/docs/README.html
@@ -1,27 +1,42 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="" xml:lang="">
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
+  <meta charset="utf-8" />
   <meta name="generator" content="pandoc" />
-  <title></title>
-  <style type="text/css">code{white-space: pre;}</style>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
+  <title>README</title>
+  <style type="text/css">
+      code{white-space: pre-wrap;}
+      span.smallcaps{font-variant: small-caps;}
+      span.underline{text-decoration: underline;}
+      div.column{display: inline-block; vertical-align: top; width: 50%;}
+  </style>
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
-<h2 id="how-to-get-started----create-imager-on-a-usb-stick">How to Get Started -- Create IMAGER on a USB Stick</h2>
+<h2 id="put-imager-on-a-usb-stickto-copy-internet-in-a-box-microsd-cards">Put IMAGER on a USB Stick—to copy Internet-in-a-Box microSD cards!</h2>
 <ul>
-<li>IMAGER makes it easy to back up, shrink (truncate) and copy Internet-in-a-Box microSD cards, on almost any Windows computer.</li>
-<li>Amazingly, IMAGER even allows you to copy to microSD cards that are &quot;just a bit too small&quot; (when extremely annoying size differences between manufacturers prevent other copying tools from working!)</li>
-<li>In future Mac computers may be supported as well.</li>
-<li>On the Linux OS, please use the <a href="https://www.linuxnix.com/what-you-should-know-about-linux-dd-command/">dd</a> and <a href="https://github.com/iiab/iiab-factory/blob/master/box/rpi/howto-mkimg.txt">min-sd and cp-sd</a> commands (min-sd is the underlying magic that shrinks or truncates microSD cards, without any data loss).</li>
+<li>IMAGER makes it easy to back up, shrink (truncate) and copy Internet-in-a-Box microSD cards, on almost any Windows computer.
+<ul>
+<li>Amazingly, IMAGER even allows you to copy to microSD cards that are “just a bit too small” (a godsend when each manufacturer’s microSD card is a slightly different size, which prevents other copying tools from working!)</li>
+<li>IMAGER <em>can</em> be converted to run on Mac computers <em>if</em> the need is very strong.</li>
+<li>On the Linux OS, please use the <a href="https://www.linuxnix.com/what-you-should-know-about-linux-dd-command/">dd</a>, <a href="https://github.com/iiab/iiab-factory/blob/master/box/rpi/howto-mkimg.txt">min-sd and cp-sd</a> commands (min-sd is the underlying magic that shrinks or truncates microSD cards, without any data loss).</li>
+</ul></li>
 <li>DOWNLOAD the most recent IMAGER from <a href="http://download.iiab.io/packages/imager/">download.iiab.io/packages/imager</a>. Depending on the speed of your Internet, this could take a while (IMAGER is about 112 MB).</li>
-<li>Use <a href="https://etcher.io">Etcher.io</a> or <a href="https://sourceforge.net/projects/win32diskimager/">sourceforge.net/projects/win32diskimager</a> to flash (burn) the downloaded .img file onto a USB stick — all USB stick data will be lost!</li>
-<li>Make sure that your Windows computer's BIOS is set to boot first from USB.</li>
-<li>Setting the BIOS may require that you strike the F1, F2, F10, F12, or Delete key just after turning on the power.</li>
-<li>Look for a BIOS setting called &quot;boot options&quot; or &quot;boot order&quot;, and make sure the USB drive (USB stick) comes first.</li>
-<li>Put the USB stick into your Windows computer, and turn on the power.</li>
-<li>After a short time you should see the colorful boot process of Tiny Core Linux, and eventually the IMAGER menu as shown in IMAGER's <a href="https://github.com/iiab/iiab-factory/blob/master/box/rpi/imager/docs/GET-STARTED-GUIDE.md">GET STARTED GUIDE</a>.</li>
-<li>Begin copying Internet-in-a-Box microSD cards!</li>
+<li>Use <a href="https://etcher.io">Etcher.io</a> or <a href="https://sourceforge.net/projects/win32diskimager/">sourceforge.net/projects/win32diskimager</a> to flash (burn) the downloaded .img file onto a USB stick—<em>remember that all prior USB stick data will be lost.</em></li>
+<li>Make sure that your Windows computer’s <a href="http://www.boot-disk.com/boot_priority.htm">BIOS is set to boot USB</a> devices first.
+<ul>
+<li>Setting the BIOS may require that you strike the ESC, F1, F2, F8, F10, F12, or Delete key—<em>just after you power on the computer.</em></li>
+<li>Look for a BIOS setting called “boot options” or “boot order”, and make sure the USB stick/drive/device comes first.</li>
+</ul></li>
+<li>Put the USB stick into your Windows computer, then turn on the computer.
+<ul>
+<li>After a short time you should see the colorful boot process of Tiny Core Linux, and eventually the IMAGER menu as shown in IMAGER’s <a href="https://github.com/iiab/iiab-factory/blob/master/box/rpi/imager/docs/GET-STARTED-GUIDE.md">GET STARTED GUIDE</a>.</li>
+<li>Begin copying Internet-in-a-Box microSD cards :-)</li>
+<li>Kindly provide <a href="http://FAQ.IIAB.IO#What_are_the_best_places_for_community_support.3F">feedback</a> to help schools, libaries &amp; clinics around the world improve on this humanitarian work, <em>Thank You!</em></li>
+</ul></li>
 </ul>
 </body>
 </html>

--- a/box/rpi/imager/docs/README.html
+++ b/box/rpi/imager/docs/README.html
@@ -35,7 +35,7 @@
 <ul>
 <li>After a short time you should see the colorful boot process of Tiny Core Linux, and eventually the IMAGER menu as shown in IMAGER’s <a href="https://github.com/iiab/iiab-factory/blob/master/box/rpi/imager/docs/GET-STARTED-GUIDE.md">GET STARTED GUIDE</a>.</li>
 <li>Begin copying Internet-in-a-Box microSD cards :-)</li>
-<li>Kindly provide <a href="http://FAQ.IIAB.IO#What_are_the_best_places_for_community_support.3F">feedback</a> to help schools, libaries &amp; clinics around the world improve on this humanitarian work, <em>Thank You!</em></li>
+<li>Kindly provide <a href="http://FAQ.IIAB.IO#What_are_the_best_places_for_community_support.3F">feedback</a> to help schools, libaries &amp; clinics around the world improve on this humanitarian work, <em>Thank You!</em> Source code is <a href="https://github.com/iiab/iiab-factory/tree/master/box/rpi/imager">here</a>, for those able to contribute even more directly.</li>
 </ul></li>
 </ul>
 </body>

--- a/box/rpi/imager/docs/README.md
+++ b/box/rpi/imager/docs/README.md
@@ -12,4 +12,4 @@
 * Put the USB stick into your Windows computer, then turn on the computer.
     * After a short time you should see the colorful boot process of Tiny Core Linux, and eventually the IMAGER menu as shown in IMAGER's [GET STARTED GUIDE](https://github.com/iiab/iiab-factory/blob/master/box/rpi/imager/docs/GET-STARTED-GUIDE.md).
     * Begin copying Internet-in-a-Box microSD cards :-)
-    * Please provide [feedback](http://FAQ.IIAB.IO#What_are_the_best_places_for_community_support.3F) to help schools, libaries & clinics around the world improve on this humanitarian work, _Thank You!_
+    * Kindly provide [feedback](http://FAQ.IIAB.IO#What_are_the_best_places_for_community_support.3F) to help schools, libaries & clinics around the world improve on this humanitarian work, _Thank You!_

--- a/box/rpi/imager/docs/README.md
+++ b/box/rpi/imager/docs/README.md
@@ -12,4 +12,4 @@
 * Put the USB stick into your Windows computer, then turn on the computer.
     * After a short time you should see the colorful boot process of Tiny Core Linux, and eventually the IMAGER menu as shown in IMAGER's [GET STARTED GUIDE](https://github.com/iiab/iiab-factory/blob/master/box/rpi/imager/docs/GET-STARTED-GUIDE.md).
     * Begin copying Internet-in-a-Box microSD cards :-)
-    * Kindly provide [feedback](http://FAQ.IIAB.IO#What_are_the_best_places_for_community_support.3F) to help schools, libaries & clinics around the world improve on this humanitarian work, _Thank You!_
+    * Kindly provide [feedback](http://FAQ.IIAB.IO#What_are_the_best_places_for_community_support.3F) to help schools, libaries & clinics around the world improve on this humanitarian work, _Thank You!_  Source code is [here](https://github.com/iiab/iiab-factory/tree/master/box/rpi/imager), for those able to contribute even more directly.

--- a/box/rpi/imager/docs/README.md
+++ b/box/rpi/imager/docs/README.md
@@ -3,13 +3,13 @@
 * IMAGER makes it easy to back up, shrink (truncate) and copy Internet-in-a-Box microSD cards, on almost any Windows computer.
     * Amazingly, IMAGER even allows you to copy to microSD cards that are "just a bit too small" (a godsend when each manufacturer's microSD card is a slightly different size, which prevents other copying tools from working!)
     * IMAGER _can_ be converted to run on Mac computers _if_ the need is very strong.
-    * On the Linux OS, please use the [dd](https://www.linuxnix.com/what-you-should-know-about-linux-dd-command/) and [min-sd and cp-sd](https://github.com/iiab/iiab-factory/blob/master/box/rpi/howto-mkimg.txt) commands (min-sd is the underlying magic that shrinks or truncates microSD cards, without any data loss).
+    * On the Linux OS, please use the [dd](https://www.linuxnix.com/what-you-should-know-about-linux-dd-command/), [min-sd and cp-sd](https://github.com/iiab/iiab-factory/blob/master/box/rpi/howto-mkimg.txt) commands (min-sd is the underlying magic that shrinks or truncates microSD cards, without any data loss).
 * DOWNLOAD the most recent IMAGER from [download.iiab.io/packages/imager](http://download.iiab.io/packages/imager/).  Depending on the speed of your Internet, this could take a while (IMAGER is about 112 MB).
-* Use [Etcher.io](https://etcher.io) or [sourceforge.net/projects/win32diskimager](https://sourceforge.net/projects/win32diskimager/) to flash (burn) the downloaded .img file onto a USB stick &mdash; all USB stick data will be lost!
+* Use [Etcher.io](https://etcher.io) or [sourceforge.net/projects/win32diskimager](https://sourceforge.net/projects/win32diskimager/) to flash (burn) the downloaded .img file onto a USB stick&mdash;_remember that all prior USB stick data will be lost._
 * Make sure that your Windows computer's [BIOS is set to boot USB](http://www.boot-disk.com/boot_priority.htm) devices first.
-    * Setting the BIOS may require that you strike the ESC, F1, F2, F8, F10, F12, or Delete key &mdash; just after you power on the computer.
-    * Look for a BIOS setting called "boot options" or "boot order", and make sure the USB drive (USB stick) comes first.
+    * Setting the BIOS may require that you strike the ESC, F1, F2, F8, F10, F12, or Delete key&mdash;_just after you power on the computer._
+    * Look for a BIOS setting called "boot options" or "boot order", and make sure the USB stick/drive/device comes first.
 * Put the USB stick into your Windows computer, then turn on the computer.
     * After a short time you should see the colorful boot process of Tiny Core Linux, and eventually the IMAGER menu as shown in IMAGER's [GET STARTED GUIDE](https://github.com/iiab/iiab-factory/blob/master/box/rpi/imager/docs/GET-STARTED-GUIDE.md).
     * Begin copying Internet-in-a-Box microSD cards :-)
-    * Please provide [feedback](http://FAQ.IIAB.IO#What_are_the_best_places_for_community_support.3F) to help schools, libaries & clinics around the world improve on this humanitarian work, Thank You!
+    * Please provide [feedback](http://FAQ.IIAB.IO#What_are_the_best_places_for_community_support.3F) to help schools, libaries & clinics around the world improve on this humanitarian work, _Thank You!_

--- a/box/rpi/imager/docs/README.md
+++ b/box/rpi/imager/docs/README.md
@@ -1,13 +1,14 @@
 ## How to Get Started -- Create IMAGER on a USB Stick
 * IMAGER makes it easy to back up, shrink (truncate) and copy Internet-in-a-Box microSD cards, on almost any Windows computer.
-  * Amazingly, IMAGER even allows you to copy to microSD cards that are "just a bit too small" (when extremely annoying size differences between manufacturers prevent other copying tools from working!)
-  * In future Mac computers may be supported as well.
-  * On the Linux OS, please use the [dd](https://www.linuxnix.com/what-you-should-know-about-linux-dd-command/) and [min-sd and cp-sd](https://github.com/iiab/iiab-factory/blob/master/box/rpi/howto-mkimg.txt) commands (min-sd is the underlying magic that shrinks or truncates microSD cards, without any data loss).
+    * Amazingly, IMAGER even allows you to copy to microSD cards that are "just a bit too small" (a godsend when each manufacturer's microSD card is a slightly different size, which prevents other copying tools from working!)
+    * IMAGER _can_ be converted to run on Mac computers _if_ the need is very strong.
+    * On the Linux OS, please use the [dd](https://www.linuxnix.com/what-you-should-know-about-linux-dd-command/) and [min-sd and cp-sd](https://github.com/iiab/iiab-factory/blob/master/box/rpi/howto-mkimg.txt) commands (min-sd is the underlying magic that shrinks or truncates microSD cards, without any data loss).
 * DOWNLOAD the most recent IMAGER from [download.iiab.io/packages/imager](http://download.iiab.io/packages/imager/).  Depending on the speed of your Internet, this could take a while (IMAGER is about 112 MB).
 * Use [Etcher.io](https://etcher.io) or [sourceforge.net/projects/win32diskimager](https://sourceforge.net/projects/win32diskimager/) to flash (burn) the downloaded .img file onto a USB stick &mdash; all USB stick data will be lost!
 * Make sure that your Windows computer's BIOS is set to boot first from USB.
-  * Setting the BIOS may require that you strike the F1, F2, F10, F12, or Delete key just after turning on the power.
-  * Look for a BIOS setting called "boot options" or "boot order", and make sure the USB drive (USB stick) comes first.
+    * Setting the BIOS may require that you strike the F1, F2, F10, F12, or Delete key just after turning on the power.
+    * Look for a BIOS setting called "boot options" or "boot order", and make sure the USB drive (USB stick) comes first.
 * Put the USB stick into your Windows computer, and turn on the power.
-  * After a short time you should see the colorful boot process of Tiny Core Linux, and eventually the IMAGER menu as shown in IMAGER's [GET STARTED GUIDE](https://github.com/iiab/iiab-factory/blob/master/box/rpi/imager/docs/GET-STARTED-GUIDE.md).
-  * Begin copying Internet-in-a-Box microSD cards!
+    * After a short time you should see the colorful boot process of Tiny Core Linux, and eventually the IMAGER menu as shown in IMAGER's [GET STARTED GUIDE](https://github.com/iiab/iiab-factory/blob/master/box/rpi/imager/docs/GET-STARTED-GUIDE.md).
+    * Begin copying Internet-in-a-Box microSD cards.
+    * Please provide [feedback](http://wiki.laptop.org/go/IIAB/FAQ#What_are_the_best_places_for_community_support.3F) to help schools, libaries & clinics around the world improve on this humanitarian work!

--- a/box/rpi/imager/docs/README.md
+++ b/box/rpi/imager/docs/README.md
@@ -1,14 +1,15 @@
-## How to Get Started -- Create IMAGER on a USB Stick
+## Put IMAGER on a USB Stick&mdash;to copy Internet-in-a-Box microSD cards!
+
 * IMAGER makes it easy to back up, shrink (truncate) and copy Internet-in-a-Box microSD cards, on almost any Windows computer.
     * Amazingly, IMAGER even allows you to copy to microSD cards that are "just a bit too small" (a godsend when each manufacturer's microSD card is a slightly different size, which prevents other copying tools from working!)
     * IMAGER _can_ be converted to run on Mac computers _if_ the need is very strong.
     * On the Linux OS, please use the [dd](https://www.linuxnix.com/what-you-should-know-about-linux-dd-command/) and [min-sd and cp-sd](https://github.com/iiab/iiab-factory/blob/master/box/rpi/howto-mkimg.txt) commands (min-sd is the underlying magic that shrinks or truncates microSD cards, without any data loss).
 * DOWNLOAD the most recent IMAGER from [download.iiab.io/packages/imager](http://download.iiab.io/packages/imager/).  Depending on the speed of your Internet, this could take a while (IMAGER is about 112 MB).
 * Use [Etcher.io](https://etcher.io) or [sourceforge.net/projects/win32diskimager](https://sourceforge.net/projects/win32diskimager/) to flash (burn) the downloaded .img file onto a USB stick &mdash; all USB stick data will be lost!
-* Make sure that your Windows computer's BIOS is set to boot first from USB.
-    * Setting the BIOS may require that you strike the F1, F2, F10, F12, or Delete key just after turning on the power.
+* Make sure that your Windows computer's [BIOS is set to boot USB](http://www.boot-disk.com/boot_priority.htm) devices first.
+    * Setting the BIOS may require that you strike the ESC, F1, F2, F8, F10, F12, or Delete key &mdash; just after you power on the computer.
     * Look for a BIOS setting called "boot options" or "boot order", and make sure the USB drive (USB stick) comes first.
-* Put the USB stick into your Windows computer, and turn on the power.
+* Put the USB stick into your Windows computer, then turn on the computer.
     * After a short time you should see the colorful boot process of Tiny Core Linux, and eventually the IMAGER menu as shown in IMAGER's [GET STARTED GUIDE](https://github.com/iiab/iiab-factory/blob/master/box/rpi/imager/docs/GET-STARTED-GUIDE.md).
-    * Begin copying Internet-in-a-Box microSD cards.
-    * Please provide [feedback](http://wiki.laptop.org/go/IIAB/FAQ#What_are_the_best_places_for_community_support.3F) to help schools, libaries & clinics around the world improve on this humanitarian work!
+    * Begin copying Internet-in-a-Box microSD cards :-)
+    * Please provide [feedback](http://FAQ.IIAB.IO#What_are_the_best_places_for_community_support.3F) to help schools, libaries & clinics around the world improve on this humanitarian work, Thank You!


### PR DESCRIPTION
See user-facing improvements to ease the pains of newbie implementer/operators:
http://download.iiab.io/packages/imager/ (specifically, its README.html)

Driven off its somewhat friendlier source doc:
https://github.com/iiab/iiab-factory/blob/master/box/rpi/imager/docs/README.md

Also some automatic modernizations to the HTML of IMAGER's [GET STARTED GUIDE](https://github.com/iiab/iiab-factory/blob/master/box/rpi/imager/docs/GET-STARTED-GUIDE.md) will appear in IMAGER v0.3 when that's later released, as a result of upgrading from pandoc 1.16-1.19 to pandoc 2.2.x

Builds on #47, #48