### PR TITLE
Clean up PR #55

### DIFF
--- a/README.html
+++ b/README.html
@@ -1,3 +1,4 @@
+<!-- For http://d.iiab.io/README.html -- usable in version subdirectories too -->
 <!-- Copied from https://github.com/iiab/iiab-factory/blob/master/README.html -->
 
 <pre>

--- a/README.html
+++ b/README.html
@@ -1,0 +1,29 @@
+<!-- Copied from https://github.com/iiab/iiab-factory/blob/master/README.html -->
+
+<pre>
+Internet-in-a-Box (IIAB) 6.7 pre-releases can be installed from this page.
+
+Please read our DRAFT <a href="https://github.com/iiab/iiab/wiki/IIAB-6.7-Release-Notes">IIAB 6.7 Release Notes</a>.  To install IIAB 6.7 onto
+<a href="https://www.raspberrypi.org/downloads/raspbian/">Raspbian Stretch</a>, <a href="http://releases.ubuntu.com/18.04/">Ubuntu 18.04</a> or <a href="https://www.debian.org/distrib/">Debian 9</a>, run this 1-line installer:
+
+               curl <a href="http://d.iiab.io/install.txt">d.iiab.io/install.txt</a> | sudo bash
+
+OS TIPS & TRICKS: click the above link (that ends in .txt) for important
+recommendations on how to PREPARE & SECURE YOUR OS.
+
+WARNING: NOOBS IS *NOT* SUPPORTED, as its partitioning is very different.
+To attempt IIAB 6.7 on <a href=https://github.com/iiab/iiab/wiki/IIAB-Platforms>another Linux</a> see the <a href="https://github.com/iiab/iiab/wiki/IIAB-Installation#do-everything-from-scratch">full/manual instructions</a>.
+
+An Ethernet cable is HIGHLY RECOMMENDED during installation, as this is more
+reliable than Wi-Fi (and faster too!)  If however you must install over Wi-Fi,
+remember to run "iiab-hotspot-on" after IIAB installation, TO ACTIVATE YOUR
+RASPBERRY PI's INTERNAL WIFI HOTSPOT (thereby killing Internet connectivity!)
+
+        Thanks For Building Your Own Library To Serve One & All
+
+Write to bugs @ iiab.io if you find issues, Thank You!  Special Thanks to the
+countries+communities+volunteers who worked non-stop to bring about <a href="http://wiki.laptop.org/go/IIAB/6.7">IIAB 6.7</a>!
+
+IIAB Development Team
+<a href="http://FAQ.IIAB.IO">http://FAQ.IIAB.IO</a>
+</pre>

--- a/iiab
+++ b/iiab
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Original here: https://github.com/iiab/iiab-factory/blob/master/iiab
 
 # To install Internet-in-a-Box (IIAB) 6.7 / pre-release onto Raspbian Stretch,
 # Ubuntu 18.04 or Debian 9, run this 1-line installer:

--- a/iiab
+++ b/iiab
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Original here: https://github.com/iiab/iiab-factory/blob/master/iiab
+# Copied from: https://github.com/iiab/iiab-factory/blob/master/iiab
 
 # To install Internet-in-a-Box (IIAB) 6.7 / pre-release onto Raspbian Stretch,
 # Ubuntu 18.04 or Debian 9, run this 1-line installer:

--- a/install.txt
+++ b/install.txt
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Original here: https://github.com/iiab/iiab-factory/blob/master/install.txt
 
 # To install Internet-in-a-Box (IIAB) 6.7 / pre-release onto Raspbian Stretch,
 # Ubuntu 18.04 or Debian 9, run this 1-line installer:

--- a/install.txt
+++ b/install.txt
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Original here: https://github.com/iiab/iiab-factory/blob/master/install.txt
+# Copied from: https://github.com/iiab/iiab-factory/blob/master/install.txt
 
 # To install Internet-in-a-Box (IIAB) 6.7 / pre-release onto Raspbian Stretch,
 # Ubuntu 18.04 or Debian 9, run this 1-line installer:


### PR DESCRIPTION
Cleans up PR #55, internally highlighting GitHub source file location in all 3 cases (install.txt, iiab, README.html).   For implementers who want to keep track of where their installer files are coming from.