### PR TITLE
Warn installers that they may need to connect to IIAB (after software itself is installed)

### DIFF
--- a/iiab
+++ b/iiab
@@ -267,6 +267,9 @@ echo -e "   http://box/admin"
 echo -e "   http://box.lan/admin"
 echo -e "   http://172.18.96.1/admin\n"
 
+echo -e "Sometimes you'll instead need http://localhost/admin or a custom IP"
+echo -e "address, as provided by your building's network administrator.\n"
+
 echo -e "Please read http://FAQ.IIAB.IO for default passwords and more!\n"
 
 reboot

--- a/iiab
+++ b/iiab
@@ -32,8 +32,17 @@
 # 7. IIAB AUTO-REBOOTS WHEN DONE (typically 1-to-2 hours later) which sets
 #    hostname, improves RTC + memory mgmt, and starts BitTorrents if necessary
 
-# 8. EXPLORE IIAB: http://box or http://box.lan or http://172.18.96.1 THEN
-#    ADD CONTENT at http://box.lan/admin -- passwords are at http://FAQ.IIAB.IO
+# 8. (A) TRY TO CONNECT ANY LAPTOP TO WI-FI HOTSPOT "Internet in a Box".
+#        If this works, verify that you can browse to http://box or
+#        http://box.lan or http://172.18.96.1
+#    (B) IF THESE ALL DON'T WORK, try http://localhost from the IIAB itself.
+#    (C) IF ALL ABOVE DON'T WORK, ask the person who set up the network/router
+#        in your building for the IP address of your IIAB, so you can browse to
+#        it using (something like) http://192.168.0.100
+
+# 9. ADD CONTENT using http://box.lan/admin (change "box.lan" as above!)
+#    Please read "What are the default passwords?" and "How do I customize my
+#    Internet-in-a-Box home page?" at http://FAQ.IIAB.IO
 
 # Thanks   For   Building   Your   Own   Library   To   Serve   One   &   All
 #

--- a/iiab
+++ b/iiab
@@ -35,7 +35,7 @@
 # 8. (A) TRY TO CONNECT ANY LAPTOP TO WI-FI HOTSPOT "Internet in a Box".
 #        If this works, verify that you can browse to http://box or
 #        http://box.lan or http://172.18.96.1
-#    (B) IF THESE ALL DON'T WORK, try http://localhost from the IIAB itself.
+#    (B) IF THOSE ALL DON'T WORK, try http://localhost from the IIAB itself.
 #    (C) IF ALL ABOVE DON'T WORK, ask the person who set up the network/router
 #        in your building for the IP address of your IIAB, so you can browse to
 #        it using (something like) http://192.168.0.100
@@ -267,9 +267,13 @@ echo -e "   http://box/admin"
 echo -e "   http://box.lan/admin"
 echo -e "   http://172.18.96.1/admin\n"
 
-echo -e "Sometimes you'll instead need http://localhost/admin or a custom IP"
-echo -e "address, as provided by your building's network administrator.\n"
+echo -e "IF THOSE ALL DON'T WORK, try http://localhost/admin from the IIAB itself.\n"
 
-echo -e "Please read http://FAQ.IIAB.IO for default passwords and more!\n"
+echo -e "IF ALL ABOVE DON'T WORK, ask the person who set up the network/router in your"
+echo -e "building for the IP address of your IIAB, so you can browse to it using"
+echo -e "(something like) http://192.168.0.100/admin\n"
+
+echo -e 'PLEASE READ "What are the default passwords?" and "How do I customize my'
+echo -e 'Internet-in-a-Box home page?" at http://FAQ.IIAB.IO'
 
 reboot

--- a/install.txt
+++ b/install.txt
@@ -32,8 +32,17 @@
 # 7. IIAB AUTO-REBOOTS WHEN DONE (typically 1-to-2 hours later) which sets
 #    hostname, improves RTC + memory mgmt, and starts BitTorrents if necessary
 
-# 8. EXPLORE IIAB: http://box or http://box.lan or http://172.18.96.1 THEN
-#    ADD CONTENT at http://box.lan/admin -- passwords are at http://FAQ.IIAB.IO
+# 8. (A) TRY TO CONNECT ANY LAPTOP TO WI-FI HOTSPOT "Internet in a Box".
+#        If this works, verify that you can browse to http://box or
+#        http://box.lan or http://172.18.96.1
+#    (B) IF THESE ALL DON'T WORK, try http://localhost from the IIAB itself.
+#    (C) IF ALL ABOVE DON'T WORK, ask the person who set up the network/router
+#        in your building for the IP address of your IIAB, so you can browse to
+#        it using (something like) http://192.168.0.100
+
+# 9. ADD CONTENT using http://box.lan/admin (change "box.lan" as above!)
+#    Please read "What are the default passwords?" and "How do I customize my
+#    Internet-in-a-Box home page?" at http://FAQ.IIAB.IO
 
 # Thanks   For   Building   Your   Own   Library   To   Serve   One   &   All
 #

--- a/install.txt
+++ b/install.txt
@@ -35,7 +35,7 @@
 # 8. (A) TRY TO CONNECT ANY LAPTOP TO WI-FI HOTSPOT "Internet in a Box".
 #        If this works, verify that you can browse to http://box or
 #        http://box.lan or http://172.18.96.1
-#    (B) IF THESE ALL DON'T WORK, try http://localhost from the IIAB itself.
+#    (B) IF THOSE ALL DON'T WORK, try http://localhost from the IIAB itself.
 #    (C) IF ALL ABOVE DON'T WORK, ask the person who set up the network/router
 #        in your building for the IP address of your IIAB, so you can browse to
 #        it using (something like) http://192.168.0.100


### PR DESCRIPTION
Towards fixing implementers' confusion within iiab/iiab#1583.

These new explanations will be made even stronger (in-lined into IIAB's install process) as part of iiab/iiab#1582 &mdash; but already these explanations will help serve those who've never before installed IIAB.