### PR TITLE
Clarify IIAB speed on RPi 3, 3 B+, 4, x86_64

### DIFF
--- a/iiab
+++ b/iiab
@@ -98,8 +98,9 @@ else
     echo -e "\n\nInstalling Internet-in-a-Box requires /etc/iiab/local_vars.yml"
     echo -e "Do you want (1) 🚵 MIN-sized (2) 🚢🚣 MEDIUM-sized or (3) 🚂🚃🚃 BIG-sized?\n"
 
-    echo -e "These take about 1, 2 or 3 hours to complete on Raspberry Pi -- depending"
-    echo -e "on Internet speed, CPU speed/temperature and microSD card/disk speed.\n"
+    echo -e "These take about 1, 2 or 3 hours on an older Raspberry Pi 3 or 3 B+, depending"
+    echo -e "on Internet speed, CPU speed/temperature and microSD card/disk speed.  Please"
+    echo -e "use a Raspberry Pi 4 or x86_64 to install in about an hour or less !\n"
 
     echo -e 'See "What can I do with E-books and Internet-in-a-Box?" and "What services'
     echo -e '(IIAB apps) are suggested during installation?" within http://FAQ.IIAB.IO\n'


### PR DESCRIPTION
1-line installer in-line documentation clarified.

IIAB's BIG-sized software install seems to work acceptably even on 1GB RPi 4 after yesterday's tests (despite valid concerns at iiab/iiab#1911, yes let's keep monitoring).

While also remembering that BIG-sized is *not* for field implementation &mdash; but rather its purpose is in fact to trial & learn about the many different/possible IIAB Apps a.k.a. services &mdash; _which is equally important!_