### PR TITLE
Speedup / comment out apt testing->stable workaround for Raspbian 2019-06-20

### DIFF
--- a/iiab
+++ b/iiab
@@ -140,9 +140,9 @@ echo -e " ██                                                                
 echo -e " ██████████████████████████████████████████████████████████████████████████████"
 
 echo -e "\n\n'apt update' is checking for OS updates...\n"
-echo -e "2019-07-11 TEMP WORKAROUND FOR RASPBIAN BUSTER'S testing->stable apt GLITCH...\nDetails @ https://github.com/iiab/iiab/issues/1856\n"
-apt -y update || true    # Overrides 'set -e'
-echo -e "\nNOW THE REAL 'apt update' WILL RUN...\n"
+#echo -e "2019-07-11 TEMP WORKAROUND FOR RASPBIAN BUSTER'S testing->stable apt GLITCH...\nDetails @ https://github.com/iiab/iiab/issues/1856\n"
+#apt -y update || true    # Overrides 'set -e'
+#echo -e "\nNOW THE REAL 'apt update' WILL RUN...\n"
 apt -qq update > /tmp/apt.stdout 2> /tmp/apt.stderr || true    # Overrides 'set -e'
 if [ $(wc -c < /tmp/apt.stderr) -gt 82 ]; then    # apt.stderr typically contains exactly 82 characters when there are no errors, no matter the primary locale, i.e. 3-line file "\nWARNING: apt does not have a stable CLI interface. Use with caution in scripts.\n\n" ...OR... in other cases more than 82, e.g. many lines of errors when apt is busy/locked/offline/etc
     echo -e "'apt update' FAILED. VERIFY YOU'RE ONLINE and resolve all errors below:\n"


### PR DESCRIPTION
As #1856 is largely now ancient history, as there have been 2 subsequent releases of Raspbian since June...the keyboard issue @georgejhunt mentions there (if it's still ongoing?) is separate!

Related:

#1960 "IIAB's 1-line installer should *require* a recent OS e.g. (a recent version of) Raspbian Buster"
