### PR TITLE
Temp Ansible workaround (revert 2.8.6 to 2.7.14) so MEDIUM-sized & BIG-sized IIAB installs work

### DIFF
--- a/iiab
+++ b/iiab
@@ -208,7 +208,7 @@ echo -e "\n\nINSTALL ANSIBLE + CORE IIAB SOFTWARE + ADMIN CONSOLE / CONTENT PACK
 
 echo -e "Install Ansible..."
 cd $BASEDIR/iiab/scripts/
-./ansible
+./ansible-2.7.x    # 2019-10-20: TEMPORARY WORKAROUND, REVERTING ANSIBLE 2.8.6 TO 2.7.14 DUE TO lineinfile BUG, PREVENTING Calibre-Web INSTALL: https://github.com/iiab/iiab/issues/2010
 
 echo -e "\n┌──────────────────────────────────────────────────────────────────────────────┐"
 echo -e "│                                                                              │"


### PR DESCRIPTION
Allows IIAB installs (http://download.iiab.io) to work over the coming day/weeks until Ansible cleans up its act (fixing Ansible 2.8.6's regression @ iiab/iiab#2010).

Of course Raspbian's kernel still confuses newbies who have not run `rpi-update` (iiab/iiab#1993) but that too should be resolved within not too many days or worst case weeks, so both of these workarounds are no longer necessary...