### PR TITLE
Experimentally transition master from ./ansible-2.7.x to ./ansible-2.9.x

### DIFF
--- a/iiab
+++ b/iiab
@@ -208,7 +208,7 @@ echo -e "\n\nINSTALL ANSIBLE + CORE IIAB SOFTWARE + ADMIN CONSOLE / CONTENT PACK
 
 echo -e "Install Ansible..."
 cd $BASEDIR/iiab/scripts/
-./ansible-2.7.x    # 2019-10-20: TEMPORARY WORKAROUND, REVERTING ANSIBLE 2.8.6 TO 2.7.14 DUE TO lineinfile BUG, PREVENTING Calibre-Web INSTALL: https://github.com/iiab/iiab/issues/2010
+./ansible-2.9.x    # BULDING ON 2019-10-20'S TEMPORARY WORKAROUND REVERTING ANSIBLE 2.8.6 TO 2.7.14 DUE TO lineinfile BUG, PREVENTING Calibre-Web INSTALL: https://github.com/iiab/iiab/issues/2010
 
 echo -e "\n┌──────────────────────────────────────────────────────────────────────────────┐"
 echo -e "│                                                                              │"


### PR DESCRIPTION
Experimentally support the new Ansible 2.9.0rc5 whose PPA was just published @ https://launchpad.net/~ansible/+archive/ubuntu/ansible-2.9

Alongside PR https://github.com/iiab/iiab/pull/2006