### PR TITLE
Apt kernel

### DIFF
--- a/iiab
+++ b/iiab
@@ -56,6 +56,7 @@ REVISION="1273"    # supplied by pri-update
 # used 1273 to test apt skip kernel below
 # need to retrive the version from the image
 IMAGE_REV="1273"
+USE_MASTER=0
 
 # A. Subroutine for B. and D.  Returns true (0) if username ($1) exists with password ($2)
 check_user_pwd() {
@@ -93,13 +94,17 @@ if check_user_pwd "iiab-admin" "g0adm1n"; then
     echo iiab-admin:"$ans" | chpasswd || true    # Overrides 'set -e'
 fi
 
-mkdir -p $FLAGDIR
 if [ -f $FLAGDIR/iiab-complete ]; then
     echo -e "\n\nIIAB INSTALLATION (/usr/sbin/iiab) IS ALREADY COMPLETE -- per existence of:"
     echo -e "$FLAGDIR/iiab-complete -- nothing to do.\n"
     exit 0
 fi
+mkdir -p $FLAGDIR
 
+check_branch(){
+    cd $BASEDIR/iiab
+    git branch | grep release-7 | wc -l
+}
 # Subroutine compares software version numbers.  Generates rare false positives
 # like "1.0 > 1" and "2.4.0 > 2.4".  Avoid risks by structuring conditionals w/
 # a consistent # of decimal points e.g. "if version_gt w.x.y.z a.b.c.d; then"
@@ -131,6 +136,29 @@ else
         exit 1
     else
         good_rev=1
+    fi
+fi
+
+# existing installs would have local_vars
+if [ -f $CONFDIR/local_vars.yml ]; then
+    if check_branch == 1; then
+        echo -e "found release-7.X branch would you like (re)install using the latest master?[Y/n]"
+#        ans=""
+#        if [ $INTERACTIVE == 1 ]; then
+#            read -t 5 ans < /dev/tty
+#        fi
+        read ans < /dev/tty
+        if [ "$ans" == "y" ] || [ "$ans" == "Y" ]; then
+            USE_MASTER=1
+        else
+            echo "remaning on release-7.X branch updating"
+            cd $BASE/iiab
+            git checkout release-7.0
+            git pull
+            cd $BASE/iiab-admin-console
+            git checkout v0.3.7
+            git pull
+        fi
     fi
 fi
 
@@ -225,8 +253,8 @@ elif grep -q 'apt list --upgradable' /tmp/apt.stdout; then    # apt.stdout typic
         apt -y dist-upgrade
         reboot
     fi
+#    cat /tmp/apt.stdout    # "All packages are up to date.\n"
 fi
-cat /tmp/apt.stdout    # "All packages are up to date.\n"
 
 ######################### INTERACTIVE STUFF IS ABOVE #########################
 
@@ -243,13 +271,33 @@ mkdir -p $BASEDIR
 cd $BASEDIR
 echo
 if [ -d iiab ]; then
-    echo -e "REPO EXISTS? Consider 'cd /opt/iiab/iiab; git pull'"
+    if [ "$USE_MASTER" -eq 1 ]; then
+        cd iiab
+        git checkout -b master > /dev/null 2> /dev/null || true # covers older curls of release-7.0
+        git config branch.master.remote origin # covers older curls of release-7.0
+        git config branch.master.merge refs/heads/master # covers older curls of release-7.0
+        git checkout master
+        git pull
+        cd $BASEDIR
+    else
+        echo -e "REPO EXISTS? Consider 'cd /opt/iiab/iiab; git pull'"
+    fi
 else
     git clone https://github.com/iiab/iiab --depth 1
 fi
 echo
 if [ -d iiab-admin-console ]; then
-    echo -e "REPO EXISTS? Consider 'cd /opt/iiab/iiab-admin-console; git pull'"
+    if [ "$USE_MASTER" -eq 1 ]; then
+        cd iiab-admin-console
+        git checkout -b master > /dev/null 2> /dev/null || true # covers older curls of release-7.0
+        git config branch.master.remote origin # covers older curls of release-7.0
+        git config branch.master.merge refs/heads/master # covers older curls of release-7.0
+        git checkout master
+        git pull
+        cd $BASEDIR
+    else
+        echo -e "REPO EXISTS? Consider 'cd /opt/iiab/iiab-admin-console; git pull'"
+    fi
 else
     git clone https://github.com/iiab/iiab-admin-console --depth 1
 fi
@@ -264,6 +312,7 @@ fi
 echo -e "\n\nINSTALL ANSIBLE + CORE IIAB SOFTWARE + ADMIN CONSOLE / CONTENT PACK MENUS...\n"
 
 echo -e "Install Ansible..."
+# could just use $BASEDIR/iiab/scripts/ansible-2.9.x without the 'cd'
 cd $BASEDIR/iiab/scripts/
 ./ansible-2.9.x    # BULDING ON 2019-10-20'S TEMPORARY WORKAROUND REVERTING ANSIBLE 2.8.6 TO 2.7.14 DUE TO lineinfile BUG, PREVENTING Calibre-Web INSTALL: https://github.com/iiab/iiab/issues/2010
 

--- a/iiab
+++ b/iiab
@@ -48,6 +48,11 @@ export DEBIAN_FRONTEND=noninteractive    # Bypass (most!) interactive questions
 BASEDIR=/opt/iiab
 CONFDIR=/etc/iiab
 FLAGDIR=$CONFDIR/install-flags
+OS=`grep ^ID= /etc/*release|cut -d= -f2`
+OS=${OS//\"/}
+CURR_KERN=`uname -r`
+MIN_RPI_KERN=4.9.59-v7+    # UPDATE THIS SOON...when Raspbian's Oct 2019 kernels are finally fixed (https://github.com/iiab/iiab/issues/1993 etc)
+REVISION="1274"
 
 # A. Subroutine for B. and D.  Returns true (0) if username ($1) exists with password ($2)
 check_user_pwd() {
@@ -136,6 +141,29 @@ else
 
         echo -e "2) After you're done editing, RUN 'sudo iiab' TO CONTINUE!\n"
         exit 0
+    fi
+fi
+
+# Subroutine compares software version numbers.  Generates rare false positives
+# like "1.0 > 1" and "2.4.0 > 2.4".  Avoid risks by structuring conditionals w/
+# a consistent # of decimal points e.g. "if version_gt w.x.y.z a.b.c.d; then"
+version_gt() { [ "$(printf '%s\n' "$@" | sort -V | head -1)" != "$1" ]; }
+
+# Verify that Raspbian is running a recent enough kernel.  As Raspbian
+# updates on 4.9.41-v7+ broke bridging, WiFi AP & OpenVPN in Oct/Nov 2017.
+echo "Found Kernel "$CURR_KERN""
+if [ "$OS" == "raspbian" ] && version_gt $MIN_RPI_KERN $CURR_KERN ; then
+    echo -e "\nEXITING: Kernel "$MIN_RPI_KERN" or higher required with Raspbian."
+    echo -e "PLEASE RUN 'apt update' then 'apt install raspberrypi-kernel' then reboot."
+    echo -e "IIAB INSTALL INSTRUCTIONS: https://github.com/iiab/iiab/wiki/IIAB-Installation"
+    exit 1
+else
+    # grab the kernel revison number
+    rev=`uname -a | awk '{print $4}' | sed 's/#//'`
+    echo "Found Kernel revison "$rev"
+    if [ "$rev" -lt "$REVISION" ] ; then
+        echo -e "waiting on upstream kernel"
+        exit 1
     fi
 fi
 

--- a/iiab
+++ b/iiab
@@ -106,7 +106,7 @@ fi
 version_gt() { [ "$(printf '%s\n' "$@" | sort -V | head -1)" != "$1" ]; }
 
 get_apt_list() {
-    apt list --upgradable | grep -v Listing | awk -F "/" '{print $1}'
+    apt list --upgradable | grep -v Listing  | grep -v kernel | grep -v ansible | awk -F "/" '{print $1}'
 }
 
 # Verify that Raspbian is running a recent enough kernel. As Raspbian kernels installed via debs
@@ -191,7 +191,7 @@ echo -e " ███████████████████████�
 echo -ne "\nHit [ENTER] to confirm you'll TRY TO RERUN 'sudo iiab' IF THERE IS A PROBLEM: "
 read ans < /dev/tty
 
-echo -e "\n\n'apt update' is checking for OS updates...\n"
+echo -e "'apt update' is checking for OS updates...\n"
 #echo -e "2019-07-11 TEMP WORKAROUND FOR RASPBIAN BUSTER'S testing->stable apt GLITCH...\nDetails @ https://github.com/iiab/iiab/issues/1856\n"
 #apt -y update || true    # Overrides 'set -e'
 #echo -e "\nNOW THE REAL 'apt update' WILL RUN...\n"
@@ -201,18 +201,23 @@ if [ $(wc -c < /tmp/apt.stderr) -gt 82 ]; then    # apt.stderr typically contain
     cat /tmp/apt.stderr
     exit 1
 elif grep -q 'apt list --upgradable' /tmp/apt.stdout; then    # apt.stdout typically contains {"All packages are up to date.\n" [even if primary locale is French & Hindi!], "Todos los paquetes están actualizados.\n", "所有软件包均为最新。\n"} ...OR... {"5 packages can be upgraded. Run 'apt list --upgradable' to see them.\n" [even if primary locale is French & Hindi!], "Se puede actualizar 1 paquete. Ejecute «apt list --upgradable» para verlo.\n", "有 1 个软件包可以升级。请执行 ‘apt list --upgradable’ 来查看它们。\n"}
-    cat /tmp/apt.stdout
-    if [ "$OS" == "raspbian" ] && [ $good_rev -eq 1 ]; then
-        updates=`get_apt_list | grep -v kernel | grep -v ansible`
-        echo -e "\nYour OS will now be upgraded...this takes time.\n"
+#    cat /tmp/apt.stdout
+    # start bypass
+    if [ "$OS" == "raspbian" ] && [ "$good_rev" -eq 1 ]; then
         echo -e "Excluding: kernel ansible \n"
-        echo -e "Installing updated packages: \n"
-        echo -e "$updates\n"
-        echo -n "Hit [ENTER] to proceed "
-        read ans < /dev/tty
-        apt -y install $updates
-    else
-# THEN IT WILL AUTO-REBOOT.\n"
+        updates=`get_apt_list`
+        echo "$updates"
+        if [ ! -z "$updates" ]; then
+            echo -e "$updates\n"
+            echo -e "Installing updated packages: \n"
+            echo -e "Your OS will now be upgraded...this takes time.\n"
+            echo -n "Hit [ENTER] to proceed "
+            read ans < /dev/tty
+            apt -y install $updates
+        else
+            echo -e "Nothing to do, proceeding...."
+        fi
+    else ## end bypass
         echo -e "\nYour OS will now be upgraded...this takes time. THEN IT WILL AUTO-REBOOT.\n"
         echo -n "Hit [ENTER] to confirm you'll RUN 'sudo iiab' AFTER IT REBOOTS: "
         read ans < /dev/tty
@@ -221,7 +226,7 @@ elif grep -q 'apt list --upgradable' /tmp/apt.stdout; then    # apt.stdout typic
         reboot
     fi
 fi
-#cat /tmp/apt.stdout    # "All packages are up to date.\n"
+cat /tmp/apt.stdout    # "All packages are up to date.\n"
 
 ######################### INTERACTIVE STUFF IS ABOVE #########################
 

--- a/iiab
+++ b/iiab
@@ -52,7 +52,10 @@ OS=`grep ^ID= /etc/*release|cut -d= -f2`
 OS=${OS//\"/}
 CURR_KERN=`uname -r`
 MIN_RPI_KERN=4.9.59-v7+    # UPDATE THIS SOON...when Raspbian's Oct 2019 kernels are finally fixed (https://github.com/iiab/iiab/issues/1993 etc)
-REVISION="1274"
+REVISION="1273"    # supplied by pri-update
+# used 1273 to test apt skip kernel below
+# need to retrive the version from the image
+IMAGE_REV="1273"
 
 # A. Subroutine for B. and D.  Returns true (0) if username ($1) exists with password ($2)
 check_user_pwd() {
@@ -95,6 +98,40 @@ if [ -f $FLAGDIR/iiab-complete ]; then
     echo -e "\n\nIIAB INSTALLATION (/usr/sbin/iiab) IS ALREADY COMPLETE -- per existence of:"
     echo -e "$FLAGDIR/iiab-complete -- nothing to do.\n"
     exit 0
+fi
+
+# Subroutine compares software version numbers.  Generates rare false positives
+# like "1.0 > 1" and "2.4.0 > 2.4".  Avoid risks by structuring conditionals w/
+# a consistent # of decimal points e.g. "if version_gt w.x.y.z a.b.c.d; then"
+version_gt() { [ "$(printf '%s\n' "$@" | sort -V | head -1)" != "$1" ]; }
+
+get_apt_list() {
+    apt list --upgradable | grep -v Listing | awk -F "/" '{print $1}'
+}
+
+# Verify that Raspbian is running a recent enough kernel. As Raspbian kernels installed via debs
+# replaces /lib/modules/* without retaining the running kernel's modules directory needing a reboot
+# to avoid a kernel module mismatch when loading kernel modules.
+# Note rpi-update retains the older modules directory
+echo "Found Kernel "$CURR_KERN""
+if [ "$OS" == "raspbian" ] && version_gt $MIN_RPI_KERN $CURR_KERN ; then
+    # grab the kernel revison number
+    rev=`uname -a | awk '{print $4}' | sed 's/#//'`
+    echo -e "Found Kernel revison "$rev"\n"
+    echo -e "\nEXITING: Kernel "$MIN_RPI_KERN" or higher required with Raspbian."
+    echo -e "PLEASE RUN 'apt update' then 'apt install raspberrypi-kernel' then reboot."
+    echo -e "IIAB INSTALL INSTRUCTIONS: https://github.com/iiab/iiab/wiki/IIAB-Installation"
+    exit 1
+else
+    # grab the kernel revison number
+    rev=`uname -a | awk '{print $4}' | sed 's/#//'`
+    echo -e "Found Kernel revison "$rev"\n"
+    if [ "$rev" -lt "$REVISION" ] && [ ! "$rev" -eq "$IMAGE_REV" ]; then
+        echo -e "waiting on upstream kernel\n"
+        exit 1
+    else
+        good_rev=1
+    fi
 fi
 
 # E. Position & customize $CONFDIR/local_vars.yml
@@ -144,33 +181,6 @@ else
     fi
 fi
 
-# Subroutine compares software version numbers.  Generates rare false positives
-# like "1.0 > 1" and "2.4.0 > 2.4".  Avoid risks by structuring conditionals w/
-# a consistent # of decimal points e.g. "if version_gt w.x.y.z a.b.c.d; then"
-version_gt() { [ "$(printf '%s\n' "$@" | sort -V | head -1)" != "$1" ]; }
-
-get_apt_list() {
-    apt list --upgradable | grep -v Listing | awk -F "/" '{print $1}'
-}
-
-# Verify that Raspbian is running a recent enough kernel.  As Raspbian
-# updates on 4.9.41-v7+ broke bridging, WiFi AP & OpenVPN in Oct/Nov 2017.
-echo "Found Kernel "$CURR_KERN""
-if [ "$OS" == "raspbian" ] && version_gt $MIN_RPI_KERN $CURR_KERN ; then
-    echo -e "\nEXITING: Kernel "$MIN_RPI_KERN" or higher required with Raspbian."
-    echo -e "PLEASE RUN 'apt update' then 'apt install raspberrypi-kernel' then reboot."
-    echo -e "IIAB INSTALL INSTRUCTIONS: https://github.com/iiab/iiab/wiki/IIAB-Installation"
-    exit 1
-else
-    # grab the kernel revison number
-    rev=`uname -a | awk '{print $4}' | sed 's/#//'`
-    echo "Found Kernel revison "$rev"
-    if [ "$rev" -lt "$REVISION" ] ; then
-        echo -e "waiting on upstream kernel"
-        exit 1
-    fi
-fi
-
 # F. Mandate OS SECURITY/UPDATES if 'apt update' has any (IF SO REBOOT)
 # Educate implementer while waiting for 'apt update'
 echo -e "\n\n ██████████████████████████████████████████████████████████████████████████████"
@@ -178,6 +188,8 @@ echo -e " ██                                                                
 echo -e " ██  RUN 'sudo iiab' IF THIS INSTALL SCRIPT EVER FAILS, TO TRY TO CONTINUE!  ██"
 echo -e " ██                                                                          ██"
 echo -e " ██████████████████████████████████████████████████████████████████████████████"
+echo -ne "\nHit [ENTER] to confirm you'll TRY TO RERUN 'sudo iiab' IF THERE IS A PROBLEM: "
+read ans < /dev/tty
 
 echo -e "\n\n'apt update' is checking for OS updates...\n"
 #echo -e "2019-07-11 TEMP WORKAROUND FOR RASPBIAN BUSTER'S testing->stable apt GLITCH...\nDetails @ https://github.com/iiab/iiab/issues/1856\n"
@@ -190,22 +202,26 @@ if [ $(wc -c < /tmp/apt.stderr) -gt 82 ]; then    # apt.stderr typically contain
     exit 1
 elif grep -q 'apt list --upgradable' /tmp/apt.stdout; then    # apt.stdout typically contains {"All packages are up to date.\n" [even if primary locale is French & Hindi!], "Todos los paquetes están actualizados.\n", "所有软件包均为最新。\n"} ...OR... {"5 packages can be upgraded. Run 'apt list --upgradable' to see them.\n" [even if primary locale is French & Hindi!], "Se puede actualizar 1 paquete. Ejecute «apt list --upgradable» para verlo.\n", "有 1 个软件包可以升级。请执行 ‘apt list --upgradable’ 来查看它们。\n"}
     cat /tmp/apt.stdout
-    echo -e "\nYour OS will now be upgraded...this takes time.\n"
+    if [ "$OS" == "raspbian" ] && [ $good_rev -eq 1 ]; then
+        updates=`get_apt_list | grep -v kernel | grep -v ansible`
+        echo -e "\nYour OS will now be upgraded...this takes time.\n"
+        echo -e "Excluding: kernel ansible \n"
+        echo -e "Installing updated packages: \n"
+        echo -e "$updates\n"
+        echo -n "Hit [ENTER] to proceed "
+        read ans < /dev/tty
+        apt -y install $updates
+    else
 # THEN IT WILL AUTO-REBOOT.\n"
-#    echo -n "Hit [ENTER] to confirm you'll RUN 'sudo iiab' AFTER IT REBOOTS: "
-#    read ans < /dev/tty
-#    echo
-#    apt -y dist-upgrade
-#    reboot
-    if [ "$OS" == "raspbian" ]; then
-        updates="get_apt_list | grep -v kernel"
-        apt install $updates
+        echo -e "\nYour OS will now be upgraded...this takes time. THEN IT WILL AUTO-REBOOT.\n"
+        echo -n "Hit [ENTER] to confirm you'll RUN 'sudo iiab' AFTER IT REBOOTS: "
+        read ans < /dev/tty
+        echo
+        apt -y dist-upgrade
+        reboot
     fi
 fi
-cat /tmp/apt.stdout    # "All packages are up to date.\n"
-
-echo -ne "\nHit [ENTER] to confirm you'll TRY TO RERUN 'sudo iiab' IF THERE IS A PROBLEM: "
-read ans < /dev/tty
+#cat /tmp/apt.stdout    # "All packages are up to date.\n"
 
 ######################### INTERACTIVE STUFF IS ABOVE #########################
 

--- a/iiab
+++ b/iiab
@@ -149,6 +149,10 @@ fi
 # a consistent # of decimal points e.g. "if version_gt w.x.y.z a.b.c.d; then"
 version_gt() { [ "$(printf '%s\n' "$@" | sort -V | head -1)" != "$1" ]; }
 
+get_apt_list() {
+    apt list --upgradable | grep -v Listing | awk -F "/" '{print $1}'
+}
+
 # Verify that Raspbian is running a recent enough kernel.  As Raspbian
 # updates on 4.9.41-v7+ broke bridging, WiFi AP & OpenVPN in Oct/Nov 2017.
 echo "Found Kernel "$CURR_KERN""
@@ -186,13 +190,17 @@ if [ $(wc -c < /tmp/apt.stderr) -gt 82 ]; then    # apt.stderr typically contain
     exit 1
 elif grep -q 'apt list --upgradable' /tmp/apt.stdout; then    # apt.stdout typically contains {"All packages are up to date.\n" [even if primary locale is French & Hindi!], "Todos los paquetes están actualizados.\n", "所有软件包均为最新。\n"} ...OR... {"5 packages can be upgraded. Run 'apt list --upgradable' to see them.\n" [even if primary locale is French & Hindi!], "Se puede actualizar 1 paquete. Ejecute «apt list --upgradable» para verlo.\n", "有 1 个软件包可以升级。请执行 ‘apt list --upgradable’ 来查看它们。\n"}
     cat /tmp/apt.stdout
-    echo -e "\nYour OS will now be upgraded...this takes time. THEN IT WILL AUTO-REBOOT.\n"
-
-    echo -n "Hit [ENTER] to confirm you'll RUN 'sudo iiab' AFTER IT REBOOTS: "
-    read ans < /dev/tty
-    echo
-    apt -y dist-upgrade
-    reboot
+    echo -e "\nYour OS will now be upgraded...this takes time.\n"
+# THEN IT WILL AUTO-REBOOT.\n"
+#    echo -n "Hit [ENTER] to confirm you'll RUN 'sudo iiab' AFTER IT REBOOTS: "
+#    read ans < /dev/tty
+#    echo
+#    apt -y dist-upgrade
+#    reboot
+    if [ "$OS" == "raspbian" ]; then
+        updates="get_apt_list | grep -v kernel"
+        apt install $updates
+    fi
 fi
 cat /tmp/apt.stdout    # "All packages are up to date.\n"
 

--- a/iiab
+++ b/iiab
@@ -120,7 +120,7 @@ get_apt_list() {
 # Note rpi-update retains the older modules directory
 echo "Found Kernel "$CURR_KERN""
 if [ "$OS" == "raspbian" ] && version_gt $MIN_RPI_KERN $CURR_KERN ; then
-    # grab the kernel revison number
+# grab the kernel revison number
     rev=`uname -a | awk '{print $4}' | sed 's/#//'`
     echo -e "Found Kernel revison "$rev"\n"
     echo -e "\nEXITING: Kernel "$MIN_RPI_KERN" or higher required with Raspbian."
@@ -128,14 +128,21 @@ if [ "$OS" == "raspbian" ] && version_gt $MIN_RPI_KERN $CURR_KERN ; then
     echo -e "IIAB INSTALL INSTRUCTIONS: https://github.com/iiab/iiab/wiki/IIAB-Installation"
     exit 1
 else
-    # grab the kernel revison number
+# grab the kernel revison number
     rev=`uname -a | awk '{print $4}' | sed 's/#//'`
     echo -e "Found Kernel revison "$rev"\n"
     if [ "$rev" -lt "$REVISION" ] && [ ! "$rev" -eq "$IMAGE_REV" ]; then
-        echo -e "waiting on upstream kernel\n"
+        echo -e "Waiting on upstream apt kernel\n"
         echo -e "https://github.com/iiab/iiab/issues/1993\n"
+# lets not risk having pri-update's kernel being undone when the apt kernel
+# would be installed below.
+        echo -e "Workaround RUN 'apt update' then 'apt install raspberrypi-kernel'"
+        echo -e "Workaround RUN 'rpi-update' at your own risk then REBOOT\n"
+        echo -n "RUN 'sudo iiab' AFTER IT REBOOTS\n"
         exit 1
     else
+# good to go with rpi-update having been run bumping the revison number
+# in uname -a
         good_rev=1
     fi
 fi

--- a/iiab
+++ b/iiab
@@ -133,6 +133,7 @@ else
     echo -e "Found Kernel revison "$rev"\n"
     if [ "$rev" -lt "$REVISION" ] && [ ! "$rev" -eq "$IMAGE_REV" ]; then
         echo -e "waiting on upstream kernel\n"
+        echo -e "https://github.com/iiab/iiab/issues/1993\n"
         exit 1
     else
         good_rev=1


### PR DESCRIPTION
1. lockout installing if kernel will get updated to a known broken version
2. skip kernel update if using pi-gen images as those have a working kernel.
3. optional update to master branch if using pi-gen images which would pull in 'installed' functionality in master that had been pre-installed in the images.