### PR TITLE
Connecting to 5 GHz WiFi-to-Internet can end up sabotaging IIAB's internal hotspot: warn implementers early on

### DIFF
--- a/README.html
+++ b/README.html
@@ -17,7 +17,10 @@ On a Raspberry Pi, <a href="https://www.raspberrypi.org/documentation/installati
 To attempt IIAB 7.2 on <a href=https://github.com/iiab/iiab/wiki/IIAB-Platforms#operating-systems>another Linux</a> see the <a href="https://github.com/iiab/iiab/wiki/IIAB-Installation#do-everything-from-scratch">full/manual instructions</a>.
 
 An Ethernet cable is HIGHLY RECOMMENDED during installation, as this is more
-reliable than Wi-Fi (and faster too!)<!--  If however you must install over Wi-Fi,
+reliable than Wi-Fi (and faster too!)  WARNING: IF YOU CONNECT YOUR IIAB'S
+INTERNAL WIFI TO THE INTERNET OVER 5 GHz, YOU'LL PREVENT OLDER LAPTOPS/PHONES/
+TABLETS (WHICH REQUIRE 2.4 GHz) FROM CONNECTING TO YOUR IIAB'S INTERNAL
+HOTSPOT.  See: "wifi_up_down: True" in /etc/iiab/local_vars.yml<!--  If however you must install over Wi-Fi,
 remember to run "iiab-hotspot-on" after IIAB installation, TO ACTIVATE YOUR
 RASPBERRY PI's INTERNAL WIFI HOTSPOT (thereby killing Internet connectivity!)-->
 

--- a/iiab
+++ b/iiab
@@ -13,7 +13,10 @@
 #    https://github.com/iiab/iiab/wiki/IIAB-Installation#do-everything-from-scratch
 
 # 2. An Ethernet cable is HIGHLY RECOMMENDED during installation, as this is
-#    more reliable than Wi-Fi (and faster!)
+#    more reliable than WiFi (and faster!)  WARNING: IF YOU CONNECT YOUR IIAB'S
+#    INTERNAL WIFI TO THE INTERNET OVER 5 GHz, YOU'LL PREVENT OLDER LAPTOPS/
+#    PHONES/TABLETS (WHICH REQUIRE 2.4 GHz) FROM CONNECTING TO YOUR IIAB'S
+#    INTERNAL HOTSPOT.  See: "wifi_up_down: True" in /etc/iiab/local_vars.yml
 
 # 3. Run 'sudo raspi-config' on RPi, to set LOCALISATION OPTIONS
 


### PR DESCRIPTION
Builds on PR iiab/iiab#2509 "Warning about 5 GHz sabotaging IIAB's internal WiFi was not being read. So raise it within local_vars.yml & MAKE IT LOUDER"