### PR TITLE
Type (m) for local_vars_medical.yml + LOUD WARNING that BIG-sized needs 2GB RAM for http://d.iiab.io installer

### DIFF
--- a/iiab
+++ b/iiab
@@ -114,8 +114,8 @@ else
     echo -e 'See "What can I do with E-books and Internet-in-a-Box?" and "What services'
     echo -e '(IIAB apps) are suggested during installation?" within http://FAQ.IIAB.IO\n'
 
-    echo -e "WARNING: This Can Take More Than An Hour, depending on Internet speed, CPU"
-    echo -e "speed/temperature and microSD card/disk speed.\n"
+    echo -e "WARNING: This Can Take More Than An Hour, depending on Internet speed, CPU,"
+    echo -e "temperature, and the speed of your microSD card.\n"
 
     echo -n "Please type 1, 2, 3 or m then press [ENTER]: "
     read local_vars_size < /dev/tty

--- a/iiab
+++ b/iiab
@@ -109,7 +109,7 @@ else
     echo -e "\n\nInstalling Internet-in-a-Box requires $CONFDIR/local_vars.yml\n"
 
     echo -e "Do you want (1) 🚵 MIN-sized (2) 🚢🚣 MEDIUM-sized or (3) 🚂🚃🚃 BIG-sized?"
-    echo -e "Or (m) for MEDICAL?  YOU NEED 2 GB RAM OR HIGHER IF YOU CHOOSE (3) !\n"
+    echo -e "Or (m) for 🚑 MEDICAL?       YOU NEED 2 GB RAM OR HIGHER IF YOU CHOOSE (3)\n"
 
     echo -e 'See "What can I do with E-books and Internet-in-a-Box?" and "What services'
     echo -e '(IIAB apps) are suggested during installation?" within http://FAQ.IIAB.IO\n'

--- a/iiab
+++ b/iiab
@@ -106,17 +106,18 @@ if [ -f local_vars.yml ]; then
 
     echo -e "                     Google 'local_vars.yml' to learn more!"
 else
-    echo -e "\n\nInstalling Internet-in-a-Box requires $CONFDIR/local_vars.yml"
-    echo -e "Do you want (1) 🚵 MIN-sized (2) 🚢🚣 MEDIUM-sized or (3) 🚂🚃🚃 BIG-sized?\n"
+    echo -e "\n\nInstalling Internet-in-a-Box requires $CONFDIR/local_vars.yml\n"
 
-    echo -e "These take about 1, 2 or 3 hours on an older Raspberry Pi 3 or 3 B+, depending"
-    echo -e "on Internet speed, CPU speed/temperature and microSD card/disk speed.  Use a"
-    echo -e "Raspberry Pi 4 or x86_64 with 2GB RAM OR HIGHER when installing (3) BIG-sized !\n"
+    echo -e "Do you want (1) 🚵 MIN-sized (2) 🚢🚣 MEDIUM-sized or (3) 🚂🚃🚃 BIG-sized?"
+    echo -e "Or (m) for MEDICAL?  YOU NEED 2 GB RAM OR HIGHER IF YOU CHOOSE (3) !\n"
 
     echo -e 'See "What can I do with E-books and Internet-in-a-Box?" and "What services'
     echo -e '(IIAB apps) are suggested during installation?" within http://FAQ.IIAB.IO\n'
 
-    echo -n "Please type 1, 2 or 3 then press [ENTER]: "
+    echo -e "WARNING: This Can Take More Than An Hour, depending on Internet speed, CPU"
+    echo -e "speed/temperature and microSD card/disk speed.\n"
+
+    echo -n "Please type 1, 2, 3 or m then press [ENTER]: "
     read local_vars_size < /dev/tty
     echo
     case $local_vars_size in
@@ -125,6 +126,9 @@ else
             ;;
         3)
             wget -O local_vars.yml https://github.com/iiab/iiab/raw/master/vars/local_vars_big.yml
+            ;;
+        m)
+            wget -O local_vars.yml https://github.com/iiab/iiab/raw/master/vars/local_vars_medical.yml
             ;;
         *)
             wget -O local_vars.yml https://github.com/iiab/iiab/raw/master/vars/local_vars_medium.yml


### PR DESCRIPTION
It appears Kolibri (and/or possibly other IIAB apps/services) have driven up the RAM/memory requirements of BIG-sized IIAB installs, starting about a year ago.

More background @ iiab/iiab#2414