### PR TITLE
1-line installer options to (1) use {{ iiab_admin_user }} instead of iiab-admin (2) not create the admin user [and password implementation discussion]

### DIFF
--- a/iiab
+++ b/iiab
@@ -49,7 +49,7 @@ export DEBIAN_FRONTEND=noninteractive    # Bypass (most!) interactive questions
 BASEDIR=/opt/iiab
 CONFDIR=/etc/iiab
 FLAGDIR=$CONFDIR/install-flags
-APT_PATH=/usr/bin    # Avoids problematic /usr/local/bin/apt on Linux Mint
+APTPATH=/usr/bin    # Avoids problematic /usr/local/bin/apt on Linux Mint
 
 # A. Subroutine for B. and D.  Returns true (0) if username ($1) exists with password ($2)
 check_user_pwd() {
@@ -72,9 +72,9 @@ fi
 
 # C. Create user 'iiab-admin' (or any other, some prefer 'pi') as nec, with default password
 IIAB_ADMIN_USER=iiab-admin
-TMP=$(grep '^iiab_admin_user:\s' /etc/iiab/local_vars.yml 2> /dev/null | sed 's/^iiab_admin_user:\s\+\<//; s/#.*//; s/\s*$//')
-if [ "$TMP" != "" ]; then IIAB_ADMIN_USER=$TMP; fi
-#[ $TMP ] && IIAB_ADMIN_USER=$TMP  # SAME AS ABOVE
+tmp=$(grep '^iiab_admin_user:\s' /etc/iiab/local_vars.yml 2> /dev/null | sed 's/^iiab_admin_user:\s\+\<//; s/#.*//; s/\s*$//')
+if [ "$tmp" != "" ]; then IIAB_ADMIN_USER=$tmp; fi
+#[ $tmp ] && IIAB_ADMIN_USER=$tmp  # SAME AS ABOVE
 
 if ! grep -q '^iiab_admin_user_install:\s\+[fF]alse\b' /etc/iiab/local_vars.yml 2> /dev/null ; then
     if ! id -u "$IIAB_ADMIN_USER" > /dev/null 2> /dev/null; then
@@ -165,7 +165,7 @@ echo -e "\n\n'apt update' is checking for OS updates...\n"
 #echo -e "2019-07-11 TEMP WORKAROUND FOR RASPBIAN BUSTER'S testing->stable apt GLITCH...\nDetails @ https://github.com/iiab/iiab/issues/1856\n"
 #apt -y update || true    # Overrides 'set -e'
 #echo -e "\nNOW THE REAL 'apt update' WILL RUN...\n"
-$APT_PATH/apt -qq update > /tmp/apt.stdout 2> /tmp/apt.stderr || true    # Overrides 'set -e'
+$APTPATH/apt -qq update > /tmp/apt.stdout 2> /tmp/apt.stderr || true    # Overrides 'set -e'
 if [ $(wc -c < /tmp/apt.stderr) -gt 82 ]; then    # apt.stderr typically contains exactly 82 characters when there are no errors, no matter the primary locale, i.e. 3-line file "\nWARNING: apt does not have a stable CLI interface. Use with caution in scripts.\n\n" ...OR... in other cases more than 82, e.g. many lines of errors when apt is busy/locked/offline/etc
     echo -e "'apt update' FAILED. VERIFY YOU'RE ONLINE and resolve all errors below:\n"
     cat /tmp/apt.stderr
@@ -177,7 +177,7 @@ elif grep -q 'apt list --upgradable' /tmp/apt.stdout; then    # apt.stdout typic
     echo -n "Hit [ENTER] to confirm you'll RUN 'sudo iiab' AFTER IT REBOOTS: "
     read ans < /dev/tty
     echo
-    $APT_PATH/apt -y dist-upgrade
+    $APTPATH/apt -y dist-upgrade
     reboot
     exit 0    # Nec to avoid both output lines below (that confuse implementers!)
 fi
@@ -197,7 +197,7 @@ fi
 
 # H. Clone 3 IIAB repos
 echo -e "\n\nDOWNLOAD (CLONE) IIAB'S 3 KEY REPOS INTO $BASEDIR ...\n"
-$APT_PATH/apt -y install git
+$APTPATH/apt -y install git
 mkdir -p $BASEDIR
 cd $BASEDIR
 echo

--- a/iiab
+++ b/iiab
@@ -72,20 +72,27 @@ fi
 
 # C. Create user 'iiab-admin' (or any other, some prefer 'pi') as nec, with default password
 IIAB_ADMIN_USER=iiab-admin
+tmp=$(grep '^iiab_admin_user:\s' /opt/iiab/iiab/vars/default_vars.yml 2> /dev/null | sed 's/^iiab_admin_user:\s\+\<//; s/#.*//; s/\s*$//')
+if [ "$tmp" != "" ]; then IIAB_ADMIN_USER=$tmp; fi
 tmp=$(grep '^iiab_admin_user:\s' /etc/iiab/local_vars.yml 2> /dev/null | sed 's/^iiab_admin_user:\s\+\<//; s/#.*//; s/\s*$//')
 if [ "$tmp" != "" ]; then IIAB_ADMIN_USER=$tmp; fi
 #[ $tmp ] && IIAB_ADMIN_USER=$tmp  # SAME AS ABOVE
 
+IIAB_ADMIN_PUBLISHED_PWD=g0adm1n
+tmp=$(grep '^iiab_admin_published_pwd:\s' /opt/iiab/iiab/vars/default_vars.yml 2> /dev/null | sed 's/^iiab_admin_published_pwd:\s\+\<//; s/#.*//; s/\s*$//')
+if [ "$tmp" != "" ]; then IIAB_ADMIN_PUBLISHED_PWD=$tmp; fi
+#[ $tmp ] && IIAB_ADMIN_PUBLISHED_PWD=$tmp  # SAME AS ABOVE
+
 if ! grep -q '^iiab_admin_user_install:\s\+[fF]alse\b' /etc/iiab/local_vars.yml 2> /dev/null ; then
     if ! id -u "$IIAB_ADMIN_USER" > /dev/null 2> /dev/null; then
         useradd "$IIAB_ADMIN_USER"
-        echo "$IIAB_ADMIN_USER":g0adm1n | chpasswd
+        echo "$IIAB_ADMIN_USER":"$IIAB_ADMIN_PUBLISHED_PWD" | chpasswd
     fi
 fi
 
 # D. If 'iiab-admin' (or equivalent) use the default password, prompt for change
-if check_user_pwd "$IIAB_ADMIN_USER" "g0adm1n" ; then
-    echo -e "\n\nUser '$IIAB_ADMIN_USER' retains default password 'g0adm1n' per http://FAQ.IIAB.IO\n"
+if check_user_pwd "$IIAB_ADMIN_USER" "$IIAB_ADMIN_PUBLISHED_PWD" ; then
+    echo -e "\n\nUser '$IIAB_ADMIN_USER' retains default password '$IIAB_ADMIN_PUBLISHED_PWD' per http://FAQ.IIAB.IO\n"
 
     echo -e "This is for login to Internet-in-a-Box's Admin Console (http://box.lan/admin)"
     echo -e "Technical Details: https://github.com/iiab/iiab/blob/master/roles/iiab-admin\n"

--- a/iiab
+++ b/iiab
@@ -62,7 +62,7 @@ check_user_pwd() {
 }
 
 # B. Ask for password change if pi/raspberry default remains
-if check_user_pwd "pi" "raspberry"; then
+if check_user_pwd "pi" "raspberry" ; then
     echo -e "\n\nRaspberry Pi's are COMPROMISED often if the default password is not changed!\n"
 
     echo -n "What password do you want for GNU/Linux user 'pi' ? "
@@ -70,21 +70,29 @@ if check_user_pwd "pi" "raspberry"; then
     echo pi:"$ans" | chpasswd || true    # Overrides 'set -e'
 fi
 
-# C. Create user 'iiab-admin' as nec, with default password
-if ! id -u iiab-admin > /dev/null 2> /dev/null; then
-    useradd iiab-admin
-    echo iiab-admin:g0adm1n | chpasswd
+# C. Create user 'iiab-admin' (or any other, some prefer 'pi') as nec, with default password
+IIAB_ADMIN_USER=iiab-admin
+TMP=$(grep '^iiab_admin_user:\s' /etc/iiab/local_vars.yml 2> /dev/null | sed 's/^iiab_admin_user:\s\+\<//; s/#.*//; s/\s*$//')
+if [ "$TMP" != "" ]; then IIAB_ADMIN_USER=$TMP; fi
+#[ $TMP ] && IIAB_ADMIN_USER=$TMP  # SAME AS ABOVE
+
+if ! grep -q '^iiab_admin_user_install:\s\+[fF]alse\b' /etc/iiab/local_vars.yml 2> /dev/null ; then
+    if ! id -u "$IIAB_ADMIN_USER" > /dev/null 2> /dev/null; then
+        useradd "$IIAB_ADMIN_USER"
+        echo "$IIAB_ADMIN_USER":g0adm1n | chpasswd
+    fi
 fi
 
-# D. Ask for password change if iiab-admin/g0adm1n default remains
-if check_user_pwd "iiab-admin" "g0adm1n"; then
-    echo -e "\n\nUser 'iiab-admin' retains default password 'g0adm1n' per http://FAQ.IIAB.IO\n"
+# D. If 'iiab-admin' (or equivalent) use the default password, prompt for change
+if check_user_pwd "$IIAB_ADMIN_USER" "g0adm1n" ; then
+    echo -e "\n\nUser '$IIAB_ADMIN_USER' retains default password 'g0adm1n' per http://FAQ.IIAB.IO\n"
 
-    echo -e "This is for login to Internet-in-a-Box's Admin Console (http://box.lan/admin)\n"
+    echo -e "This is for login to Internet-in-a-Box's Admin Console (http://box.lan/admin)"
+    echo -e "Technical Details: https://github.com/iiab/iiab/blob/master/roles/iiab-admin\n"
 
-    echo -n "What password do you want for GNU/Linux user 'iiab-admin' ? "
+    echo -n "What password do you want for GNU/Linux user '$IIAB_ADMIN_USER' ? "
     read ans < /dev/tty    # Whines but doesn't change password if [Enter]
-    echo iiab-admin:"$ans" | chpasswd || true    # Overrides 'set -e'
+    echo "$IIAB_ADMIN_USER":"$ans" | chpasswd || true    # Overrides 'set -e'
 fi
 
 mkdir -p $FLAGDIR
@@ -233,7 +241,7 @@ cd $BASEDIR/iiab/
 if [ -f $FLAGDIR/iiab-admin-console-complete ]; then
     echo -e "ADMIN CONSOLE INSTALLATION IS ALREADY COMPLETE -- per existence of:"
     echo -e "$FLAGDIR/iiab-admin-console-complete\n"
-elif grep -q '^admin_console_install: False' /etc/iiab/local_vars.yml ; then
+elif grep -q '^admin_console_install:\s\+[fF]alse\b' /etc/iiab/local_vars.yml ; then
     echo -e "LET'S NOT TRY TO INSTALL ADMIN CONSOLE -- because:"
     echo -e "'admin_console_install: False' is in /etc/iiab/local_vars.yml\n"
 else
@@ -245,7 +253,7 @@ else
     touch $FLAGDIR/iiab-admin-console-complete
 fi
 
-if grep -q '^admin_console_enabled: False' /etc/iiab/local_vars.yml ; then
+if grep -q '^admin_console_enabled:\s\+[fF]alse\b' /etc/iiab/local_vars.yml ; then
     echo -e "'admin_console_enabled: False' is in /etc/iiab/local_vars.yml"
     echo -e "...so let's try to DISABLE & STOP Admin Console's iiab-cmdsrv.service\n"
 

--- a/iiab
+++ b/iiab
@@ -70,7 +70,7 @@ if check_user_pwd "pi" "raspberry" ; then
     echo pi:"$ans" | chpasswd || true    # Overrides 'set -e'
 fi
 
-# C. Create user 'iiab-admin' (or any other, some prefer 'pi') as nec, with default password
+# C. Create user 'iiab-admin' (or any other, some prefer 'pi' or 'ubuntu') as nec, with default password
 IIAB_ADMIN_USER=iiab-admin
 tmp=$(grep '^iiab_admin_user:\s' /opt/iiab/iiab/vars/default_vars.yml 2> /dev/null | sed 's/^iiab_admin_user:\s\+\<//; s/#.*//; s/\s*$//')
 if [ "$tmp" != "" ]; then IIAB_ADMIN_USER=$tmp; fi


### PR DESCRIPTION
Heavily tested on RaspiOS; lightly tested on Ubuntu 20.04.1

Refs:
- iiab/iiab#2561, PR iiab/iiab#2566, PR iiab/iiab#2570
- iiab/iiab-admin-console#345, PR iiab/iiab-admin-console#346, PR iiab/iiab-admin-console#347, PR iiab/iiab-admin-console#348
- PR #132, PR #151