### PR TITLE
1-line-installer fix: set a stub email address for 'git pull'

### DIFF
--- a/iiab
+++ b/iiab
@@ -244,10 +244,10 @@ fi
 # I. Install optional PR's
 echo -e "\n\nINSTALL PR's FROM iiab/iiab OR iiab/iiab-admin-console -- USAGE EXAMPLES:\n"
 echo -e "   sudo iiab 361 2604 2607"
-echo -e "   curl d.iiab.io/install.txt | sudo bash -s 361 2604 2607"
+echo -e "   curl d.iiab.io/install.txt | sudo bash -s 361 2604 2607\n"
 command -v jq &> /dev/null ||
-    $APTPATH/apt -y install jq    # sed to avoid delays?
-if [ $# != 0 ]; then    # Stub email for 'git pull' if one isn't already set
+    $APTPATH/apt -y install jq    # sed better, to avoid delays?
+if [ -s /etc/iiab/pr-queue ]; then    # Set an email address for 'git pull' if one isn't yet set
    git config --get user.email 1> /dev/null ||
        git config --global user.email "you@example.com"
    echo -e "\nYour git email is set to: $(git config --get user.email)"


### PR DESCRIPTION
Late-breaking bug fix for PR #158 to be able to pull in PR's during IIAB installs.

That slipped in during the restructuring from built-in bash vars `$#` `$*` `$@` (state in memory) to `/etc/iiab/pr-queue` (state on disk).