### PR TITLE
/usr/sbin/iiab -> /usr/bin/iiab for Debian

### DIFF
--- a/iiab
+++ b/iiab
@@ -109,7 +109,7 @@ if check_user_pwd "$IIAB_ADMIN_USER" "$IIAB_ADMIN_PUBLISHED_PWD"; then
 fi
 
 if [ -f $FLAGDIR/iiab-complete ]; then
-    echo -e "\n\nIIAB INSTALLATION (/usr/sbin/iiab) IS ALREADY COMPLETE -- per existence of:"
+    echo -e "\n\nIIAB INSTALLATION (/usr/bin/iiab) IS ALREADY COMPLETE -- per existence of:"
     echo -e "$FLAGDIR/iiab-complete -- nothing to do.\n"
     exit 0
 fi

--- a/install.txt
+++ b/install.txt
@@ -47,12 +47,12 @@
 set -e                                   # Exit on error (avoids snowballing)
 export DEBIAN_FRONTEND=noninteractive    # Bypass (most!) interactive questions
 
-# Save script to /usr/sbin/iiab (easy resume/continue mnemonic 'sudo iiab')
-mv /usr/sbin/iiab /usr/sbin/iiab.old 2> /dev/null || true    # Overrides 'set -e'
-curl https://raw.githubusercontent.com/iiab/iiab-factory/master/iiab > /usr/sbin/iiab
-chmod 0744 /usr/sbin/iiab
+# Save script to /usr/bin/iiab (easy resume/continue mnemonic 'sudo iiab')
+mv /usr/bin/iiab /usr/bin/iiab.old 2> /dev/null || true    # Overrides 'set -e'
+curl https://raw.githubusercontent.com/iiab/iiab-factory/master/iiab > /usr/bin/iiab
+chmod 0744 /usr/bin/iiab
 
 # Run install script!
-/usr/sbin/iiab "$@" # Pass on all CLI params (PR #s) for easy community testing
+/usr/bin/iiab "$@" # Pass on all CLI params (PR #s) for easy community testing
 # allowing for e.g.: curl d.iiab.io/install.txt | sudo bash -s 361 2604 2607
-# As explained in /usr/sbin/iiab Lines 244-319 ("I. Install optional PR's").
+# As explained in /usr/bin/iiab Lines 244-319 ("I. Install optional PR's").


### PR DESCRIPTION
To resolve issues with `sudo iiab` instructions failing on Debian, where `/usr/sbin` is generally not in the $PATH, as raised by @deltacloud9 at iiab/iiab#2749.