### PR TITLE
optionally run iiab-network when wifi is present

### DIFF
--- a/iiab
+++ b/iiab
@@ -429,6 +429,11 @@ fi
 
 touch $FLAGDIR/iiab-complete
 
+if ! [[ $(ls -la /sys/class/net/*/phy80211 | awk -F / '{print $5}' | wc ) == 0 ]]; then
+    cd /opt/iiab/iiab
+    ./iiab-network
+fi
+
 # M. Educate Implementers prior to rebooting!
 echo -e "\n\n         ┌───────────────────────────────────────────────────────────┐"
 echo -e "         │                                                           │"


### PR DESCRIPTION
The only time the network role is really needed is with wifi present otherwise the install is just using the os provided networking. 