### PR TITLE
Include 'yescrypt' among /etc/shadow hashing methods

### DIFF
--- a/iiab
+++ b/iiab
@@ -77,12 +77,16 @@ mkdir -p $FLAGDIR    # Which also creates /etc/iiab
 command -v grep &> /dev/null ||
     $APTPATH/apt -y install grep    # AVOID UX CLUTTER+DELAYS: 4 MORE BELOW!
 check_user_pwd() {
-    # $meth (hashing method) is typically '6' which implies 5000 rounds
-    # of SHA-512 per /etc/login.defs -> /etc/pam.d/common-password
-    meth=$(grep "^$1:" /etc/shadow | cut -d: -f2 | cut -d$ -f2)
-    salt=$(grep "^$1:" /etc/shadow | cut -d: -f2 | cut -d$ -f3)
-    hash=$(grep "^$1:" /etc/shadow | cut -d: -f2 | cut -d$ -f4)
-    [[ $(python3 -c "import crypt; print(crypt.crypt('$2', '\$$meth\$$salt'))") == "\$$meth\$$salt\$$hash" ]]
+    # 2021-08-28: New OS's use 'yescrypt' so use Perl instead of Python (#2949)
+    # This also helps avoid parsing the (NEW) 4th sub-field in $y$j9T$SALT$HASH
+    field2=$(grep "^$1:" /etc/shadow | cut -d: -f2)
+    [[ $(perl -e "print crypt('$2', '$field2')") == $field2 ]]
+    # # $meth (hashing method) is typically '6' which implies 5000 rounds
+    # # of SHA-512 per /etc/login.defs -> /etc/pam.d/common-password
+    # meth=$(grep "^$1:" /etc/shadow | cut -d: -f2 | cut -d$ -f2)
+    # salt=$(grep "^$1:" /etc/shadow | cut -d: -f2 | cut -d$ -f3)
+    # hash=$(grep "^$1:" /etc/shadow | cut -d: -f2 | cut -d$ -f4)
+    # [[ $(python3 -c "import crypt; print(crypt.crypt('$2', '\$$meth\$$salt'))") == "\$$meth\$$salt\$$hash" ]]
 }
 
 # B. Ask for password change if pi/raspberry default remains


### PR DESCRIPTION
Solves iiab/iiab#2949 in support of Debian 11 Bullseye, and the many new distros that appear to be moving beyond SHA-512 this year and in coming years.