### PR TITLE
Update download.iiab.io to latest RaspiOS instructions

### DIFF
--- a/README.html
+++ b/README.html
@@ -1,22 +1,21 @@
 <!-- For http://d.iiab.io/README.html -- usable in version subdirectories too -->
 <!-- Copied from https://github.com/iiab/iiab-factory/blob/master/README.html -->
 
-<a href=https://internet-in-a-box.org>Internet-in-a-Box (IIAB)</a> 7.2 pre-releases can be installed from this page.
+<a href=https://internet-in-a-box.org>Internet-in-a-Box (IIAB)</a> 7.2 pre-releases can be installed from this page!
 <p>
-Please read our DRAFT <a href="https://github.com/iiab/iiab/wiki/IIAB-7.2-Release-Notes">IIAB 7.2 Release Notes</a>.  To install IIAB 7.2 onto <a href="https://www.raspberrypi.org/software/">Raspberry Pi OS</a>, <a href="https://github.com/iiab/iiab/wiki/IIAB-Platforms#operating-systems">Ubuntu 20.04+</a>, <a href="https://linuxmint.com/">Linux Mint 20</a> or <a href="https://www.debian.org/releases/bullseye/debian-installer/">Debian 11</a>, run this 1-line installer:
+  Please read our DRAFT <a href="https://github.com/iiab/iiab/wiki/IIAB-7.2-Release-Notes">IIAB 7.2 Release Notes</a>.  To install IIAB 7.2 onto <a href="https://www.raspberrypi.org/software/">Raspberry Pi OS</a>, <a href="https://github.com/iiab/iiab/wiki/IIAB-Platforms#operating-systems">Ubuntu 20.04+</a>, <a href="https://linuxmint.com/">Linux Mint 20</a> or <a href="https://www.debian.org/releases/bullseye/debian-installer/">Debian 11</a>, simply run this 1-line installer:
 <p>
-<center><b>curl <a href="http://d.iiab.io/install.txt">d.iiab.io/install.txt</a> | sudo bash</b></center>
+  <center><b>curl <a href="http://d.iiab.io/install.txt">d.iiab.io/install.txt</a> | sudo bash</b></center>
 <p>
-<!--OS TIPS & TRICKS: click the above link (that ends in .txt) for important
-recommendations on how to PREPARE & SECURE YOUR OS.
-<p>-->
-WARNING: THE NOOBS OS IS *NOT* SUPPORTED, as its partitioning is very different.  On a Raspberry Pi, <a href="https://www.raspberrypi.org/documentation/installation/installing-images/README.md">WE RECOMMEND YOU INSTALL THE LATEST RASPBERRY PI OS</a>.  To attempt IIAB 7.2 on <a href=https://github.com/iiab/iiab/wiki/IIAB-Platforms#operating-systems>another Linux</a>, see the <a href="https://github.com/iiab/iiab/wiki/IIAB-Installation#do-everything-from-scratch">full/manual instructions</a>.
+  <!--OS TIPS & TRICKS: click the above link (that ends in .txt) for important recommendations on how to PREPARE & SECURE YOUR OS. <p>-->
+  WARNING: THE NOOBS OS IS *NOT* SUPPORTED, as its partitioning is very different.  On a Raspberry Pi, <a href="https://www.raspberrypi.org/software/">WE RECOMMEND YOU INSTALL THE LATEST RASPBERRY PI OS</a>, using the <a href="https://www.raspberrypi.org/documentation/computers/getting-started.html#installing-the-operating-system">detailed instructions</a> if necessary.  To attempt an IIAB install onto a <a href=https://github.com/iiab/iiab/wiki/IIAB-Platforms#operating-systems>non-supported Linux distribution</a> (AT YOUR OWN RISK) see also the <a href="https://github.com/iiab/iiab/wiki/IIAB-Installation#do-everything-from-scratch">manual/legacy instructions</a>.
 <p>
-An Ethernet cable is HIGHLY RECOMMENDED during installation, as this is more reliable than Wi-Fi (and faster too!)  WARNING: IF YOU CONNECT YOUR IIAB'S INTERNAL WIFI TO THE INTERNET OVER 5 GHz, YOU'LL PREVENT OLDER LAPTOPS/PHONES/TABLETS (WHICH REQUIRE 2.4 GHz) FROM CONNECTING TO YOUR IIAB'S INTERNAL HOTSPOT.  See: "wifi_up_down: True" in <a href=http://FAQ.IIAB.IO#What_is_local_vars.yml_and_how_do_I_customize_it.3F>/etc/iiab/local_vars.yml</a> <!--  If however you must install over Wi-Fi, remember to run "iiab-hotspot-on" after IIAB installation, TO ACTIVATE YOUR RASPBERRY PI's INTERNAL WIFI HOTSPOT (thereby killing Internet connectivity!)-->
+  An Ethernet cable is HIGHLY RECOMMENDED during installation, as this is more reliable than Wi-Fi (and faster too!)  WARNING: IF YOU CONNECT YOUR IIAB'S INTERNAL WIFI TO THE INTERNET OVER 5 GHz, YOU'LL PREVENT OLDER LAPTOPS/PHONES/TABLETS (WHICH REQUIRE 2.4 GHz) FROM CONNECTING TO YOUR IIAB'S INTERNAL HOTSPOT.  See: "wifi_up_down: True" in <a href=http://FAQ.IIAB.IO#What_is_local_vars.yml_and_how_do_I_customize_it.3F>/etc/iiab/local_vars.yml</a> <!--  If however you must install over Wi-Fi, remember to run "iiab-hotspot-on" after IIAB installation, TO ACTIVATE YOUR RASPBERRY PI's INTERNAL WIFI HOTSPOT (thereby killing Internet connectivity!)-->
 <p>
-<center><b>Thanks For Building Your Own Library To Serve One & All</b></center>
+  <center><b>Thanks For Building Your Own Library To Serve One & All</b></center>
 <p>
-Please <a href=https://internet-in-a-box.org/pages/contributing.html>contact us</a> if you find issues, Thank You!  Special Thanks to the countries + communities + volunteers working non-stop to bring about <a href="http://wiki.laptop.org/go/IIAB/7.2">IIAB 7.2</a> !
+  Please <a href=https://internet-in-a-box.org/pages/contributing.html>contact us</a> if you find issues, Thank You!  Special Thanks to the countries + communities + volunteers working non-stop to bring about <a href="http://wiki.laptop.org/go/IIAB/7.2">IIAB 7.2</a> !
 <p>
-IIAB Dev Team<br>
-<a href="http://FAQ.IIAB.IO">http://FAQ.IIAB.IO</a>
+  IIAB Dev Team
+  <br>
+  <a href="http://FAQ.IIAB.IO">http://FAQ.IIAB.IO</a>

--- a/fast.txt
+++ b/fast.txt
@@ -8,8 +8,8 @@
 
 # 1. WARNING: NOOBS IS *NOT* SUPPORTED, as its partitioning is very different.
 #    On a Raspberry Pi, WE RECOMMEND YOU INSTALL THE LATEST RASPBERRY PI OS:
-#    https://www.raspberrypi.org/documentation/installation/installing-images/README.md
-#    To attempt IIAB 7.2 on another Linux see the full/manual instructions:
+#    https://www.raspberrypi.org/documentation/computers/getting-started.html
+#    To attempt IIAB 7.2 on another Linux see the manual/legacy instructions:
 #    https://github.com/iiab/iiab/wiki/IIAB-Installation#do-everything-from-scratch
 
 # 2. An Ethernet cable is HIGHLY RECOMMENDED during installation, as this is

--- a/iiab
+++ b/iiab
@@ -8,8 +8,8 @@
 
 # 1. WARNING: NOOBS IS *NOT* SUPPORTED, as its partitioning is very different.
 #    On a Raspberry Pi, WE RECOMMEND YOU INSTALL THE LATEST RASPBERRY PI OS:
-#    https://www.raspberrypi.org/documentation/installation/installing-images/README.md
-#    To attempt IIAB 7.2 on another Linux see the full/manual instructions:
+#    https://www.raspberrypi.org/documentation/computers/getting-started.html
+#    To attempt IIAB 7.2 on another Linux see the manual/legacy instructions:
 #    https://github.com/iiab/iiab/wiki/IIAB-Installation#do-everything-from-scratch
 
 # 2. An Ethernet cable is HIGHLY RECOMMENDED during installation, as this is

--- a/install.txt
+++ b/install.txt
@@ -8,8 +8,8 @@
 
 # 1. WARNING: NOOBS IS *NOT* SUPPORTED, as its partitioning is very different.
 #    On a Raspberry Pi, WE RECOMMEND YOU INSTALL THE LATEST RASPBERRY PI OS:
-#    https://www.raspberrypi.org/documentation/installation/installing-images/README.md
-#    To attempt IIAB 7.2 on another Linux see the full/manual instructions:
+#    https://www.raspberrypi.org/documentation/computers/getting-started.html
+#    To attempt IIAB 7.2 on another Linux see the manual/legacy instructions:
 #    https://github.com/iiab/iiab/wiki/IIAB-Installation#do-everything-from-scratch
 
 # 2. An Ethernet cable is HIGHLY RECOMMENDED during installation, as this is

--- a/risky.txt
+++ b/risky.txt
@@ -8,8 +8,8 @@
 
 # 1. WARNING: NOOBS IS *NOT* SUPPORTED, as its partitioning is very different.
 #    On a Raspberry Pi, WE RECOMMEND YOU INSTALL THE LATEST RASPBERRY PI OS:
-#    https://www.raspberrypi.org/documentation/installation/installing-images/README.md
-#    To attempt IIAB 7.2 on another Linux see the full/manual instructions:
+#    https://www.raspberrypi.org/documentation/computers/getting-started.html
+#    To attempt IIAB 7.2 on another Linux see the manual/legacy instructions:
 #    https://github.com/iiab/iiab/wiki/IIAB-Installation#do-everything-from-scratch
 
 # 2. An Ethernet cable is HIGHLY RECOMMENDED during installation, as this is


### PR DESCRIPTION
As the Raspberry Pi Foundation / Trading Co has done a lot of work in recent weeks updating their docs!

Great News: the non-compatible NOOBS OS is now being de-emphasized (and possibly deprecated in future?)