### PR TITLE
Oops...1-line installer should not promote Option 0 = local_vars_unittest.yml to ppl who don't know what they're doing

### DIFF
--- a/iiab
+++ b/iiab
@@ -174,7 +174,7 @@ else
     echo -e "\n\nInstalling Internet-in-a-Box requires /etc/iiab/local_vars.yml\n"
 
     echo -e "PLEASE PICK (1) 🚵 SMALL (2) 🚢🚣 MEDIUM or (3) 🚂🚃🚃 LARGE (NEEDS 2+ GB RAM)."
-    echo -e "Or try (0) for bare-bones unit-testing.  Or (m) for 🚑 MEDICAL.\n"
+    echo -e "Or try (m) for 🚑 MEDICAL.\n"
 
     echo -e 'See "What can I do with E-books and Internet-in-a-Box?" and "What services'
     echo -e '(IIAB apps) are suggested during installation?" within http://FAQ.IIAB.IO\n'
@@ -182,7 +182,7 @@ else
     echo -e "WARNING: This Can Take More Than An Hour, depending on Internet speed, CPU,"
     echo -e "temperature, and the speed of your microSD card.\n"
 
-    echo -n "Please type 0, 1, 2, 3 or m then press [ENTER]: "
+    echo -n "Please type 1, 2, 3 or m then press [ENTER]: "
     read local_vars_size < /dev/tty
     echo
     case $local_vars_size in


### PR DESCRIPTION
Oops, apologies: VPN access should definitely not be promoted to people who don't yet know what they're doing!

This PR cleans up these 2 PR's:

- PR #193 
- PR #194 

Related:

- PR iiab/iiab#3037