### PR TITLE
Cleaner names for Raspberry Pi Imager UX + Clarify min-sd, cp-sd

### DIFF
--- a/box/rpi/cp-sd
+++ b/box/rpi/cp-sd
@@ -1,18 +1,23 @@
 #!/bin/bash -x
-# resize the SD card to minimum size and zip it to image directory
-# assume /dev/sdg2 is partition to be shrunk
-# parameter 1 - name the image e.g. raspios-11-lite-SMALL
-# parameter 2 - optional root device partition otherwise /dev/sdg2
-# parameter 3 - optional image directory otherwise CWD
+
+# (1) min-sd resizes the SD card to minimum size
+# (2) cp-sd dd's SD card's meaningful bits to image directory (parameter 3)
+# (3) zip-json-sd zips up the image and drafts a .json snippet for rpi-imager
+
+# parameter 1 - name the image e.g. SMALL-raspios-11-lite
+# parameter 2 - optional root device partition to be shrunk, otherwise /dev/sdg2
+# parameter 3 - optional image directory, otherwise CWD
+
 # Automatically determine a size for the output disk image
 # (including root, swap, and boot partitions).
 #
 # This is calculated by using resize2fs to shrink, then adding the space
-# occupied by previous partitions
-# Assumes root is last partition
+# occupied by previous partitions.
+# Assumes root is last partition.
+# There is a similar project at https://github.com/Drewsif/PiShrink
 
 if [ $# -eq 0 ]; then
-    echo "Usage: $0 name (no .img), optional rootfs device (like /dev/sdg), optional image directory (like /curation/images), otherwise CWD"
+    echo "Usage: $0 name (no .img), optional rootfs device (like /dev/sdg), optional image directory (like /curation/images) otherwise CWD"
     exit 1
 fi
 

--- a/box/rpi/cp-sd
+++ b/box/rpi/cp-sd
@@ -15,6 +15,8 @@
 # occupied by previous partitions.
 # Assumes root is last partition.
 # There is a similar project at https://github.com/Drewsif/PiShrink
+# All these techniques greatly help with:
+# http://FAQ.IIAB.IO#How_do_I_back_up,_shrink_&_copy_IIAB_microSD_cards
 
 if [ $# -eq 0 ]; then
     echo "Usage: $0 name (no .img), optional rootfs device (like /dev/sdg), optional image directory (like /curation/images) otherwise CWD"

--- a/box/rpi/cp-sd
+++ b/box/rpi/cp-sd
@@ -15,6 +15,8 @@
 # occupied by previous partitions.
 # Assumes root is last partition.
 # There is a similar project at https://github.com/Drewsif/PiShrink
+
+# SEE ALSO: howto-mkimg.txt and howto-ia-upl.txt
 # All these techniques greatly help with:
 # http://FAQ.IIAB.IO#How_do_I_back_up,_shrink_&_copy_IIAB_microSD_cards
 

--- a/box/rpi/fast.json
+++ b/box/rpi/fast.json
@@ -1,30 +1,30 @@
 {
     "os_list": [
         {
-            "name": "iiab-7.2preview2-211206-raspios-11-desktop-MEDIUM-gf7d94968.img",
-            "description": "iiab-7.2preview2-211206-raspios-11-desktop-MEDIUM-gf7d94968.img",
+            "name": "IIAB 7.2PV2 ∙ MEDIUM ∙ 32-bit RasPiOS Desktop",
+            "description": "iiab-7.2preview2-211206-MEDIUM-raspios-11-desktop-gf7d94968.img",
             "icon": "https://raw.githubusercontent.com/iiab/iiab-factory/master/box/rpi/iiab40.png",
-            "url": "https://download.iiab.io/7.2/iiab-7.2preview2-211206-raspios-11-desktop-MEDIUM-gf7d94968.img.zip",
+            "url": "https://download.iiab.io/7.2/iiab-7.2preview2-211206-MEDIUM-raspios-11-desktop-gf7d94968.img.zip",
             "extract_size": 12525416448,
             "extract_sha256": "e30d0d577583a747a562f680a75a2162781eb9e4f2241036bc592088edabd48b",
             "image_download_size": 3662147400,
             "release_date": "2021-12-06"
         },
         {
-            "name": "iiab-7.2preview2-211206-raspios-11-lite-SMALL-gf7d94968.img",
-            "description": "iiab-7.2preview2-211206-raspios-11-lite-SMALL-gf7d94968.img",
+            "name": "IIAB 7.2PV2 ∙ SMALL ∙ 32-bit RasPiOS Lite",
+            "description": "iiab-7.2preview2-211206-SMALL-raspios-11-lite-gf7d94968.img",
             "icon": "https://raw.githubusercontent.com/iiab/iiab-factory/master/box/rpi/iiab40.png",
-            "url": "https://download.iiab.io/7.2/iiab-7.2preview2-211206-raspios-11-lite-SMALL-gf7d94968.img.zip",
+            "url": "https://download.iiab.io/7.2/iiab-7.2preview2-211206-SMALL-raspios-11-lite-gf7d94968.img.zip",
             "extract_size": 8271257600,
             "extract_sha256": "c2940ad5443021a88214cb319ea9ad982ef5b68e7608c10e7a136f85dd5bcc09",
             "image_download_size": 1984679047,
             "release_date": "2021-12-06"
         },
         {
-            "name": "iiab-7.2preview2-211206-raspios-11-lite-MEDICAL-gf7d94968.img",
-            "description": "iiab-7.2preview2-211206-raspios-11-lite-MEDICAL-gf7d94968.img",
+            "name": "IIAB 7.2PV2 ∙ MEDICAL ∙ 32-bit RasPiOS Lite",
+            "description": "iiab-7.2preview2-211206-MEDICAL-raspios-11-lite-gf7d94968.img",
             "icon": "https://raw.githubusercontent.com/iiab/iiab-factory/master/box/rpi/iiab40.png",
-            "url": "https://download.iiab.io/7.2/iiab-7.2preview2-211206-raspios-11-lite-MEDICAL-gf7d94968.img.zip",
+            "url": "https://download.iiab.io/7.2/iiab-7.2preview2-211206-MEDICAL-raspios-11-lite-gf7d94968.img.zip",
             "extract_size": 5483786240,
             "extract_sha256": "c772c463a485ca1acf36d08542c9c2116b2ffdd4a568bcbe312922d036e3fe64",
             "image_download_size": 1264064638,

--- a/box/rpi/min-sd
+++ b/box/rpi/min-sd
@@ -15,6 +15,8 @@
 # occupied by previous partitions.
 # Assumes root is last partition.
 # There is a similar project at https://github.com/Drewsif/PiShrink
+# All these techniques greatly help with:
+# https://FAQ.IIAB.IO#How_do_I_back_up,_shrink_&_copy_IIAB_microSD_cards?
 
 if [ $# -eq 0 ]; then
     echo "Usage: $0 name (no .img), optional rootfs device (like /dev/sdg3), optional image directory (like /curation/images) otherwise CWD"

--- a/box/rpi/min-sd
+++ b/box/rpi/min-sd
@@ -15,6 +15,8 @@
 # occupied by previous partitions.
 # Assumes root is last partition.
 # There is a similar project at https://github.com/Drewsif/PiShrink
+
+# SEE ALSO: howto-mkimg.txt and howto-ia-upl.txt
 # All these techniques greatly help with:
 # http://FAQ.IIAB.IO#How_do_I_back_up,_shrink_&_copy_IIAB_microSD_cards?
 

--- a/box/rpi/min-sd
+++ b/box/rpi/min-sd
@@ -16,7 +16,7 @@
 # Assumes root is last partition.
 # There is a similar project at https://github.com/Drewsif/PiShrink
 # All these techniques greatly help with:
-# https://FAQ.IIAB.IO#How_do_I_back_up,_shrink_&_copy_IIAB_microSD_cards?
+# http://FAQ.IIAB.IO#How_do_I_back_up,_shrink_&_copy_IIAB_microSD_cards?
 
 if [ $# -eq 0 ]; then
     echo "Usage: $0 name (no .img), optional rootfs device (like /dev/sdg3), optional image directory (like /curation/images) otherwise CWD"

--- a/box/rpi/min-sd
+++ b/box/rpi/min-sd
@@ -1,19 +1,23 @@
 #!/bin/bash -x
-# resize the SD card to minimum size and zip it to image directory
-# assume /dev/sdg2 is partition to be shrunk
-# parameter 1 - name the image e.g. raspios-11-lite-SMALL
-# parameter 2 - optional root device partition otherwise /dev/sdg2
-# parameter 3 - optional image directory otherwise CWD
+
+# (1) min-sd resizes the SD card to minimum size
+# (2) cp-sd dd's SD card's meaningful bits to image directory (parameter 3)
+# (3) zip-json-sd zips up the image and drafts a .json snippet for rpi-imager
+
+# parameter 1 - name the image e.g. SMALL-raspios-11-lite
+# parameter 2 - optional root device partition to be shrunk, otherwise /dev/sdg2
+# parameter 3 - optional image directory, otherwise CWD
+
 # Automatically determine a size for the output disk image
 # (including root, swap, and boot partitions).
 #
 # This is calculated by using resize2fs to shrink, then adding the space
-# occupied by previous partitions
-# Assumes root is last partition
+# occupied by previous partitions.
+# Assumes root is last partition.
 # There is a similar project at https://github.com/Drewsif/PiShrink
 
 if [ $# -eq 0 ]; then
-    echo "Usage: $0 name (no .img), optional rootfs device (like /dev/sdg3), optional image directory (like /curation/images), otherwise CWD"
+    echo "Usage: $0 name (no .img), optional rootfs device (like /dev/sdg3), optional image directory (like /curation/images) otherwise CWD"
     exit 1
 fi
 
@@ -31,14 +35,14 @@ if [ ! -b $PARTITION ]; then
     exit 1
 fi
 
-if [ -z $3 ]; then
-    IMAGE_DIR=$PWD
-else
-    IMAGE_DIR=$3
-fi
-
-mkdir -p $IMAGE_DIR
-cd $IMAGE_DIR
+#if [ -z $3 ]; then
+#    IMAGE_DIR=$PWD
+#else
+#    IMAGE_DIR=$3
+#fi
+#
+#mkdir -p $IMAGE_DIR
+#cd $IMAGE_DIR
 mkdir -p /mnt/sdcard
 
 umount $PARTITION


### PR DESCRIPTION
As Raspberry Pi Imager...

1. Has a limited-length textfield to display image names, and...
2. Converts the image name to UPPERCASE, after the user makes their choice.

Refs:

- PR #199
- PR #200
- PR #201
- PR #202
- iiab/iiab#3060