### PR TITLE
Three IIAB 7.2 Preview 3 images published (box/rpi/fast.json)

### DIFF
--- a/box/rpi/fast.json
+++ b/box/rpi/fast.json
@@ -1,34 +1,34 @@
 {
     "os_list": [
         {
-            "name": "IIAB 7.2PV2 ∙ MEDIUM ∙ 32-bit RasPiOS Desktop",
-            "description": "iiab-7.2preview2-211206-MEDIUM-raspios-11-desktop-gf7d94968.img",
+            "name": "IIAB 7.2PV3 ∙ MEDIUM ∙ 32-bit RasPiOS Desktop",
+            "description": "iiab-7.2preview3-211226-MEDIUM-raspios-11-desktop-ge1de8eb1.img",
             "icon": "https://raw.githubusercontent.com/iiab/iiab-factory/master/box/rpi/iiab40.png",
-            "url": "https://download.iiab.io/7.2/iiab-7.2preview2-211206-MEDIUM-raspios-11-desktop-gf7d94968.img.zip",
-            "extract_size": 12525416448,
-            "extract_sha256": "e30d0d577583a747a562f680a75a2162781eb9e4f2241036bc592088edabd48b",
-            "image_download_size": 3662147400,
-            "release_date": "2021-12-06"
+            "url": "https://download.iiab.io/7.2/iiab-7.2preview3-211226-MEDIUM-raspios-11-desktop-ge1de8eb1.img.zip",
+            "extract_size": 12612141056,
+            "extract_sha256": "a0d5148550060c26eb6286d46324bcb0368846f17768415d42bfeb825278467e",
+            "image_download_size": 3677878629,
+            "release_date": "2021-12-26"
         },
         {
-            "name": "IIAB 7.2PV2 ∙ SMALL ∙ 32-bit RasPiOS Lite",
-            "description": "iiab-7.2preview2-211206-SMALL-raspios-11-lite-gf7d94968.img",
+            "name": "IIAB 7.2PV3 ∙ SMALL ∙ 32-bit RasPiOS Lite",
+            "description": "iiab-7.2preview3-211226-SMALL-raspios-11-lite-ge1de8eb1.img",
             "icon": "https://raw.githubusercontent.com/iiab/iiab-factory/master/box/rpi/iiab40.png",
-            "url": "https://download.iiab.io/7.2/iiab-7.2preview2-211206-SMALL-raspios-11-lite-gf7d94968.img.zip",
-            "extract_size": 8271257600,
-            "extract_sha256": "c2940ad5443021a88214cb319ea9ad982ef5b68e7608c10e7a136f85dd5bcc09",
-            "image_download_size": 1984679047,
-            "release_date": "2021-12-06"
+            "url": "https://download.iiab.io/7.2/iiab-7.2preview3-211226-SMALL-raspios-11-lite-ge1de8eb1.img.zip",
+            "extract_size": 7358398464,
+            "extract_sha256": "58fec8a3f6d940ad0ea3bed4cfb0161e1ff7ae9bb0cd167e85484df8f0c9860e",
+            "image_download_size": 1676959117,
+            "release_date": "2021-12-26"
         },
         {
-            "name": "IIAB 7.2PV2 ∙ MEDICAL ∙ 32-bit RasPiOS Lite",
-            "description": "iiab-7.2preview2-211206-MEDICAL-raspios-11-lite-gf7d94968.img",
+            "name": "IIAB 7.2PV3 ∙ MEDICAL ∙ 32-bit RasPiOS Lite",
+            "description": "iiab-7.2preview3-211226-MEDICAL-raspios-11-lite-ge1de8eb1.img",
             "icon": "https://raw.githubusercontent.com/iiab/iiab-factory/master/box/rpi/iiab40.png",
-            "url": "https://download.iiab.io/7.2/iiab-7.2preview2-211206-MEDICAL-raspios-11-lite-gf7d94968.img.zip",
-            "extract_size": 5483786240,
-            "extract_sha256": "c772c463a485ca1acf36d08542c9c2116b2ffdd4a568bcbe312922d036e3fe64",
-            "image_download_size": 1264064638,
-            "release_date": "2021-12-06"
+            "url": "https://download.iiab.io/7.2/iiab-7.2preview3-211226-MEDICAL-raspios-11-lite-ge1de8eb1.img.zip",
+            "extract_size": 5440880640,
+            "extract_sha256": "b6b8c6060c6766be1d10120a12627582b5f3f9c28a38c8fda7b61151716730ee",
+            "image_download_size": 1212716008,
+            "release_date": "2021-12-26"
         }
     ]
 }

--- a/factory-settings
+++ b/factory-settings
@@ -2,5 +2,5 @@
 # this file is sourced to supply current context
 
 PRODUCT=iiab
-VERSION=7.2preview2
+VERSION=7.2preview3
 PLATFORM=`cat /etc/os-release | grep ^ID= | cut -f2 -d=`


### PR DESCRIPTION
These can be installed on mainline OS's by running:

```
rpi-imager --repo http://iiab.io/fast.json
```

Based on **IIAB 7.2 Preview 3** released 3h ago:
https://github.com/iiab/iiab/releases/tag/7.2-preview-3

Raspberry Pi Imager instructions in detail:
https://github.com/iiab/iiab/wiki/Raspberry-Pi-Images:-Summary

Refs:

- PR #199
- PR #200
- PR #201
- PR #202
- PR #203 
- PR iiab/iiab#3060