### PR TITLE
Use flag /.expand-rootfs for /usr/sbin/iiab-expand-rootfs

### DIFF
--- a/box/generic/betafinalize.sh
+++ b/box/generic/betafinalize.sh
@@ -35,6 +35,6 @@ rm -f /etc/sysconfig/network
 rm -rf /home/.devkey.html
 rm -f /root/.netrc
 # the following will probably alread be done in minimize script
-touch /.resize-rootfs
+touch /.expand-rootfs
 
 

--- a/box/rpi/exp-sd
+++ b/box/rpi/exp-sd
@@ -4,9 +4,9 @@
 # parameter 1 - optional root device partition otherwise /dev/sdc
 
 if [ -z $1 ]; then
-   SDCARD=/dev/sdc
+    SDCARD=/dev/sdc
 else
-   SDCARD=$1
+    SDCARD=$1
 fi
 
 df
@@ -15,25 +15,24 @@ echo "Are you sure? "
 read -p "Press y to continue or any other key to stop. " -n 1 -r
 echo    # (optional) move to a new line
 
-if [[ $REPLY =~ ^[Yy]$ ]]
-then
-  echo "writing to $SDCARD"
-  SDCARD2=${SDCARD}2
-  echo $SDCARD2
-  umount $SDCARD2
-  mount $SDCARD2 /mnt/sdcard  
-  if [ -f /mnt/sdcard/.resize-rootfs ];then\
-    rm /mnt/sdcard/.resize-rootfs
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+    echo "writing to $SDCARD"
+    SDCARD2=${SDCARD}2
+    echo $SDCARD2
     umount $SDCARD2
-    echo "Starting resizing"
-    parted -s $SDCARD resizepart 2 100%
-    umount $SDCARD2
-    echo "Starting e2fsck"
-    e2fsck -f $SDCARD2
-     echo "Starting resize2fs"
-    resize2fs $SDCARD2
-    df
-  fi
+    mount $SDCARD2 /mnt/sdcard
+    if [ -f /mnt/sdcard/.expand-rootfs ]; then
+        rm /mnt/sdcard/.expand-rootfs
+        umount $SDCARD2
+        echo "Starting resizing"
+        parted -s $SDCARD resizepart 2 100%
+        umount $SDCARD2
+        echo "Starting e2fsck"
+        e2fsck -f $SDCARD2
+        echo "Starting resize2fs"
+        resize2fs $SDCARD2
+        df
+    fi
 fi
 umount ${SDCARD}1
 umount $SDCARD2

--- a/box/rpi/min-sd
+++ b/box/rpi/min-sd
@@ -62,7 +62,7 @@ if [ ! -d /mnt/sdcard/opt/iiab/iiab ]; then
     exit 1
 fi
 
-touch /mnt/sdcard/.resize-rootfs
+touch /mnt/sdcard/.expand-rootfs
 
 # create id for image
 pushd /mnt/sdcard/opt/iiab/iiab

--- a/box/rpi/wrsd
+++ b/box/rpi/wrsd
@@ -35,8 +35,7 @@ echo "Are you sure? "
 read -p "Press y to continue or any other key to stop. " -n 1 -r
 echo    # (optional) move to a new line
 
-if [[ $REPLY =~ ^[Yy]$ ]]
-then
+if [[ $REPLY =~ ^[Yy]$ ]]; then
     echo "Writing to $SDCARD"
     umount $BOOTPART $FSPART
     dd if=$IMG of=$SDCARD bs=4M status=progress
@@ -46,9 +45,9 @@ then
 
     umount $BOOTPART $FSPART
     mount  $FSPART /mnt/sdcard
-    if [ -f /mnt/sdcard/.resize-rootfs ]; then
+    if [ -f /mnt/sdcard/.expand-rootfs ]; then
         RESIZE=1
-        rm /mnt/sdcard/.resize-rootfs
+        rm /mnt/sdcard/.expand-rootfs
     fi
     umount /mnt/sdcard
 

--- a/docs/rpi-images/README.6.4.html
+++ b/docs/rpi-images/README.6.4.html
@@ -37,7 +37,7 @@
 
   <h2>Resizing the Image</h2>
   <P>The first time you boot the image it should automatically resize the root file system to the capacity of the sd card.</P>
-  <P>You can cause this to run again by issuing the command touch /.resize-rootfs</P>
+  <P>You can cause this to run again by issuing the command touch /.expand-rootfs</P>
   <P>If this does not work for some reason you can ssh into the RPi and use the raspi-config utility.</P>
 
   <h2>Updates</h2>

--- a/docs/rpi-images/README.html
+++ b/docs/rpi-images/README.html
@@ -37,7 +37,7 @@
 
   <h2>Resizing the Image</h2>
   <P>The first time you boot the image it should automatically resize the root file system to the capacity of the sd card.</P>
-  <P>You can cause this to run again by issuing the command touch /.resize-rootfs</P>
+  <P>You can cause this to run again by issuing the command touch /.expand-rootfs</P>
   <P>If this does not work for some reason you can ssh into the RPi and use the raspi-config utility.</P>
 
   <h2>Updates</h2>


### PR DESCRIPTION
So naming is consistent across the board, in keeping with raspi-config norms:

- flag `/.expand-rootfs`
- command [/usr/sbin/iiab-expand-rootfs](https://github.com/iiab/iiab/blob/master/roles/1-prep/templates/iiab-expand-rootfs)
- systemd service [/etc/systemd/system/iiab-expand-rootfs.service](https://github.com/iiab/iiab/blob/master/roles/1-prep/templates/iiab-expand-rootfs.service)

For:

- PR iiab/iiab#3137

(Legacy flag name /.resize-rootfs will still work during the interim.)

This PR also lints `box/rpi/exp-sd` and `box/rpi/wrsd`