### PR TITLE
min-sd: Delete /etc/remoteit/config.json {id, name, config, claim code}

### DIFF
--- a/box/rpi/min-sd
+++ b/box/rpi/min-sd
@@ -81,6 +81,7 @@ rm -f /mnt/sdcard/library/awstats/*
 rm -f /mnt/sdcard/var/log/apache2/*
 rm -f /mnt/sdcard/var/log/nginx/*
 rm -f /mnt/sdcard/etc/iiab/uuid
+rm -f /mnt/sdcard/etc/remoteit/config.json
 rm -f /mnt/sdcard/library/www/html/local_content/USB*
 rm -f /mnt/sdcard/usb*
 


### PR DESCRIPTION
A big thank you to @jvonau for catching this important security/privacy risk.

Without this, published/circulated IIAB images might be vulnerable to attack during the first 24h after installation of the remote.it Device Package, e.g. if the claim code in /etc/remoteit/config.json was abused.  As was mentioned here:

- PR iiab/iiab#3156