### PR TITLE
min-sd: Also delete /etc/remoteit/config.json* backups, as an additional precaution

### DIFF
--- a/box/rpi/min-sd
+++ b/box/rpi/min-sd
@@ -81,7 +81,7 @@ rm -f /mnt/sdcard/library/awstats/*
 rm -f /mnt/sdcard/var/log/apache2/*
 rm -f /mnt/sdcard/var/log/nginx/*
 rm -f /mnt/sdcard/etc/iiab/uuid
-rm -f /mnt/sdcard/etc/remoteit/config.json
+rm -f /mnt/sdcard/etc/remoteit/config.json*
 rm -f /mnt/sdcard/library/www/html/local_content/USB*
 rm -f /mnt/sdcard/usb*
 


### PR DESCRIPTION
For IIAB disk images that might be published or circulated.

Example files that will be deleted by [min-sd](https://github.com/iiab/iiab-factory/blob/master/box/rpi/min-sd) going forward:

```
root@box:~# ls /etc/remoteit/
config.json  config.json-bak1  config.json-bak2
```

Refs:

- PR #209
- PR iiab/iiab#3154
- PR iiab/iiab#3156
- PR iiab/iiab#3157