### PR TITLE
New Syntax for Devs: 'curl iiab.io/risky.txt | sudo bash' and 'sudo iiab -r'

### DIFF
--- a/iiab
+++ b/iiab
@@ -51,8 +51,11 @@ APTPATH=/usr/bin    # Avoids problematic /usr/local/bin/apt on Linux Mint
 FAST=false     # YOUR OWN RISK: Fewer security & user education prompts.
 MFABT=false    # No time to read the book?  "Move Fast and Break Things:
 # How Facebook, Google, and Amazon Cornered Culture and Undermined Democracy"
-CLONEFIRST=false    # Everyday users want installs bureaucracy-free w/o delay.
-# Developers however may want to clone first, and then set local_vars.yml
+# This option is for DEVELOPERS (syntax ~16 lines below) who also want to
+# (1) Avoid apt updates and (2) Clone first & then later set local_vars.yml
+# IN CONTRAST: newcomers, testers and implementers want installs fully
+# bureaucracy-free without delay, i.e. crisp top-line instructions unclouded
+# by git "techno-gibberish" they do not understand, before they let it rip!
 
 if [[ $(id -un) != "root" ]]; then
      echo "Please run 'sudo iiab'"

--- a/iiab
+++ b/iiab
@@ -59,16 +59,14 @@ if [[ $(id -un) != "root" ]]; then
      exit 1
 fi
 
-if [[ $1 == "-f" || $1 == "--fast" ]]; then    # curl iiab.io/fast.txt | sudo bash
+if [[ $1 == "-f" || $1 == "--fast" ]]; then
+    # FOR IMPLEMENTERS: 'curl iiab.io/fast.txt | sudo bash' AND 'sudo iiab -f'
     FAST=true
     shift
-elif [[ $1 == "-F" || $1 == "--risky" ]]; then
+elif [[ $1 == "-r" || $1 == "--risky" ]]; then
+    # FOR DEVELOPERS: 'curl iiab.io/risky.txt | sudo bash' AND 'sudo iiab -r'
     FAST=true
     MFABT=true
-    shift
-elif [[ $1 == "-c" || $1 == "--clonefirst" ]]; then    # curl iiab.io/install.txt | sudo bash -s -c
-    FAST=true
-    CLONEFIRST=true
     shift
 fi
 
@@ -190,7 +188,7 @@ fi
 
 # G. Everyday users want installs bureaucracy-free w/o delay.
 # Developers however may want to clone first, and then set local_vars.yml
-if $($CLONEFIRST); then
+if $($MFABT); then
     clone-repos;
 fi
 
@@ -319,7 +317,7 @@ fi
 
 # K. Everyday users want installs bureaucracy-free w/o delay.
 # Developers however may want to clone first, and then set local_vars.yml
-if ! $($CLONEFIRST); then
+if ! $($MFABT); then
     clone-repos;
 fi
 

--- a/iiab
+++ b/iiab
@@ -60,7 +60,7 @@ if [[ $(id -un) != "root" ]]; then
 fi
 
 if [[ $1 == "-f" || $1 == "--fast" ]]; then
-    # FOR IMPLEMENTERS: 'curl iiab.io/fast.txt | sudo bash' AND 'sudo iiab -f'
+    # FOR TESTERS: 'curl iiab.io/fast.txt | sudo bash' AND 'sudo iiab -f'
     FAST=true
     shift
 elif [[ $1 == "-r" || $1 == "--risky" ]]; then


### PR DESCRIPTION
Unfortunately `bash -s [ANY SWITCH]` will not work.

So this PR reworks the syntax for the _developer_ demographic, building on just-merged PR:

- PR #212

Too many flags become a real mess to explain + maintain over the long run.
So this PR consolidates things intentionally around one single developer flag:

- `curl iiab.io/risky.txt | sudo bash` = `sudo iiab -r` = `sudo iiab --risky`

**In summary, that means 3 core demographics &mdash; who can install IIAB in these 3 ways:**

1) The new syntax brings 2 things to developers that are not appropriate for regular implementers:

   - IIAB's 3 repos are cloned first, prior to selecting & configuring [/etc/iiab/local_vars.yml](https://wiki.iiab.io/go/FAQ#What_is_local_vars.yml_and_how_do_I_customize_it?)
   - OS apt updates are completely avoided

2) Regular _testers_ might still choose to use the following &mdash; to avoid one or 2 keystrokes &mdash; i.e. if they insist on using published passwords, entirely at their own risk (!)

   - `curl iiab.io/fast.txt | sudo bash` and `sudo iiab -f`

3) Most people (_newcomers_ especially, and _most implementers_) should continue to use:

   - `curl iiab.io/install.txt | sudo bash` and `sudo iiab`