### PR TITLE
FIX: clone-repos() prereq 'apt update' (to install git)

### DIFF
--- a/iiab
+++ b/iiab
@@ -55,7 +55,7 @@ MFABT=false    # No time to read the book?  "Move Fast and Break Things:
 # (1) Avoid OS apt updates and (2) Clone first & then later set local_vars.yml
 # IN CONTRAST: newcomers, testers and implementers want installs fully
 # bureaucracy-free without delay, i.e. crisp top-line instructions unclouded by
-# 'apt update' + 'apt install git' + 3 git clones -- before they let it rip!
+# 'apt update' + 'apt -y install git' + 3 git clones -- before they let it rip!
 
 if [[ $(id -un) != "root" ]]; then
      echo "Please run 'sudo iiab'"

--- a/iiab
+++ b/iiab
@@ -193,7 +193,7 @@ fi
 # Developers however may want to clone first, and then set local_vars.yml
 if $($MFABT); then
     command -v git &> /dev/null ||
-        apt update
+        $APTPATH/apt update
     clone-repos;
 fi
 

--- a/iiab
+++ b/iiab
@@ -193,7 +193,7 @@ fi
 # Developers however may want to clone first, and then set local_vars.yml
 if $($MFABT); then
     command -v git &> /dev/null ||
-        $APTPATH/apt update
+        $APTPATH/apt update    # -q is equivalent, and -qq is too quiet!
     clone-repos;
 fi
 

--- a/iiab
+++ b/iiab
@@ -52,10 +52,10 @@ FAST=false     # YOUR OWN RISK: Fewer security & user education prompts.
 MFABT=false    # No time to read the book?  "Move Fast and Break Things:
 # How Facebook, Google, and Amazon Cornered Culture and Undermined Democracy"
 # This option is for DEVELOPERS (syntax ~16 lines below) who also want to
-# (1) Avoid apt updates and (2) Clone first & then later set local_vars.yml
+# (1) Avoid OS apt updates and (2) Clone first & then later set local_vars.yml
 # IN CONTRAST: newcomers, testers and implementers want installs fully
-# bureaucracy-free without delay, i.e. crisp top-line instructions unclouded
-# by git "techno-gibberish" they do not understand, before they let it rip!
+# bureaucracy-free without delay, i.e. crisp top-line instructions unclouded by
+# 'apt update' + 'apt install git' + 3 git clones -- before they let it rip!
 
 if [[ $(id -un) != "root" ]]; then
      echo "Please run 'sudo iiab'"
@@ -115,7 +115,7 @@ iiab_var_value() {
 }
 
 # C. Subroutine for G. and K.  Clone 3 IIAB repos
-clone-repos() {
+clone-repos() {                        # PREREQ: 'apt update'
     echo -e "\n\nDOWNLOAD (CLONE) IIAB'S 3 KEY REPOS INTO /opt/iiab ..."
     command -v git &> /dev/null ||
         $APTPATH/apt -y install git    # AVOID UX CLUTTER+DELAYS
@@ -192,6 +192,8 @@ fi
 # G. Everyday users want installs bureaucracy-free w/o delay.
 # Developers however may want to clone first, and then set local_vars.yml
 if $($MFABT); then
+    command -v git &> /dev/null ||
+        apt update
     clone-repos;
 fi
 


### PR DESCRIPTION
When cloning near the beginning of 1-line IIAB installs (e.g. `sudo iiab -r` for developers) it now becomes necessary to run `apt update` on several OS's, in order to install `git`:

- PR #211
- PR #212 
- PR #213