### PR TITLE
Clearly Prompt for sudo password when installing IIAB (on OS's that need that⁠—typically Ubuntu, Mint, Debian)

### DIFF
--- a/README.html
+++ b/README.html
@@ -3,9 +3,9 @@
 
 <a href=https://internet-in-a-box.org>Internet-in-a-Box (IIAB)</a> 8.0 pre-releases are thoroughly tested, and can be installed from this page!  Please read our DRAFT <a href="https://github.com/iiab/iiab/wiki/IIAB-8.0-Release-Notes">IIAB 8.0 Release Notes</a>.
 <p>
-  <i>To install IIAB 8.0 onto <a href="https://www.raspberrypi.com/software/">Raspberry Pi OS</a>, <a href="https://github.com/iiab/iiab/wiki/IIAB-Platforms#operating-systems">Ubuntu 20.04+</a>, <a href="https://linuxmint.com/">Linux Mint 20</a> or <a href="https://www.debian.org/releases/bullseye/debian-installer/">Debian 11+</a>, simply run this 1-line installer:</i>
+  <i>To install IIAB 8.0 onto <a href="https://www.raspberrypi.com/software/">Raspberry Pi OS</a>, <a href="https://github.com/iiab/iiab/wiki/IIAB-Platforms#operating-systems">Ubuntu 20.04+</a>, <a href="https://linuxmint.com/">Linux Mint 20+</a> or <a href="https://www.debian.org/releases/bullseye/debian-installer/">Debian 11+</a>, simply run this 1-line installer:</i>
 <p>
-  <center><big><b><mark>curl iiab.io/install.txt | sudo bash</mark></b></big></center>
+  <center><big><b><mark>curl iiab.io/install.txt | bash</mark></b></big></center>
 <p>
   <!--OS TIPS & TRICKS: click the above link (that ends in .txt) for important recommendations on how to PREPARE & SECURE YOUR OS. <p>-->
   On a Raspberry Pi, <a href="https://www.raspberrypi.com/software/">WE RECOMMEND YOU INSTALL THE LATEST RASPBERRY PI OS (32-bit OR 64-bit)</a>, using their <a href="https://www.raspberrypi.com/documentation/computers/getting-started.html#installing-the-operating-system">detailed instructions</a> if necessary.  WARNING: THE NOOBS OS IS *NOT* SUPPORTED, as its partitioning is very different.  To attempt an IIAB install onto a <a href=https://github.com/iiab/iiab/wiki/IIAB-Platforms#operating-systems>non-supported Linux distribution</a> (AT YOUR OWN RISK) see also the <a href="https://github.com/iiab/iiab/wiki/IIAB-Installation#do-everything-from-scratch">manual/legacy instructions</a>.

--- a/fast.txt
+++ b/fast.txt
@@ -2,9 +2,9 @@
 # Copied from: https://github.com/iiab/iiab-factory/blob/master/fast.txt
 
 # To install Internet-in-a-Box (IIAB) 8.0 / pre-release onto Raspberry Pi OS,
-# Ubuntu 20.04+, Linux Mint 20 or Debian 11+, run this 1-line installer:
+# Ubuntu 20.04+, Linux Mint 20+ or Debian 11+, run this 1-line installer:
 #
-#                    curl iiab.io/fast.txt | sudo bash
+#                      curl iiab.io/fast.txt | bash
 
 # 1. WARNING: NOOBS IS *NOT* SUPPORTED, as its partitioning is very different.
 #    On a Raspberry Pi, WE RECOMMEND YOU INSTALL THE LATEST RASPBERRY PI OS:
@@ -18,19 +18,15 @@
 #    PHONES/TABLETS (WHICH REQUIRE 2.4 GHz) FROM CONNECTING TO YOUR IIAB'S
 #    INTERNAL HOTSPOT.  See: "wifi_up_down: True" in /etc/iiab/local_vars.yml
 
-# 3. Run 'sudo raspi-config' on RPi, to set LOCALISATION OPTIONS
+# 3. Run 'sudo raspi-config' on Raspberry Pi, to set LOCALISATION OPTIONS
 
 # 4. OPTIONAL: if you have slow/pricey Internet, pre-position KA Lite's
-#    mandatory 0.9 GB English Pack (en.zip) within /tmp -- you can grab a copy
-#    from https://pantry.learningequality.org/downloads/ka-lite/0.17/content/contentpacks/en.zip
+#    mandatory 0.9 GB English Pack (en.zip) within /tmp -- you can grab it from
+#    https://pantry.learningequality.org/downloads/ka-lite/0.17/content/contentpacks/en.zip
 
-# 5. WHEN YOU RUN 1-LINE INSTALLER 'curl iiab.io/fast.txt | sudo bash'
-#    YOU THEN NEED TO TYPE IN YOUR PASSWORD IF ON UBUNTU/DEBIAN/ETC (for sudo)
-#    ^^^ ^^^^ ^^^^ ^^ ^^^^ ^^ ^^^^ ^^^^^^^^
+# 5. Follow on-screen instructions (TYPE 'sudo iiab' TO RESUME IF EVER NECESS!)
 
-# 6. Follow on-screen instructions (TYPE 'sudo iiab' TO RESUME IF EVER NECESS!)
-
-# 7. Within about 1-2 hours, it will announce that INTERNET-IN-A-BOX (IIAB)
+# 6. Within about 1-2 hours, it will announce that INTERNET-IN-A-BOX (IIAB)
 #    SOFTWARE INSTALL IS COMPLETE, prompting you to reboot...TO ADD CONTENT!
 
 # Thanks   For   Building   Your   Own   Library   To   Serve   One   &   All
@@ -38,8 +34,8 @@
 # DRAFT IIAB 8.0 Release Notes:
 # https://github.com/iiab/iiab/wiki/IIAB-8.0-Release-Notes
 #
-# Write to bugs @ iiab.io if you find issues, Thank You!  Special Thanks to the
-# countries+communities+volunteers who worked non-stop to bring about IIAB 8.0!
+# SPECIAL THANKS to countries + communities + volunteers who worked non-stop
+# to bring about IIAB 8.0!  https://internet-in-a-box.org/contributing.html
 #
 # IIAB Dev Team
 # http://FAQ.IIAB.IO
@@ -48,11 +44,11 @@ set -e                                   # Exit on error (avoids snowballing)
 export DEBIAN_FRONTEND=noninteractive    # Bypass (most!) interactive questions
 
 # Save script to /usr/sbin/iiab (easy resume/continue mnemonic 'sudo iiab')
-mv /usr/sbin/iiab /usr/sbin/iiab.old 2> /dev/null || true    # Overrides 'set -e'
-curl https://raw.githubusercontent.com/iiab/iiab-factory/master/iiab > /usr/sbin/iiab
-chmod 0744 /usr/sbin/iiab
+sudo mv /usr/sbin/iiab /usr/sbin/iiab.old 2> /dev/null || true    # Overrides 'set -e'
+curl https://raw.githubusercontent.com/iiab/iiab-factory/master/iiab | sudo tee /usr/sbin/iiab > /dev/null
+sudo chmod 0744 /usr/sbin/iiab
 
 # Run install script!
-/usr/sbin/iiab --fast "$@" # Pass on all CLI params (PR #s) for easy community
-# testing.  Example: curl iiab.io/fast.txt | sudo bash -s 361 2604 2607
-# As explained in /usr/sbin/iiab Section "J. Install optional PR's"
+sudo /usr/sbin/iiab --fast "$@"    # Pass on all CLI params (PR #s) for
+# easy community testing -- SEE "Install optional PR's" in /usr/sbin/iiab
+# EXAMPLE: curl iiab.io/install.txt | bash -s 361 2604 2607

--- a/install.txt
+++ b/install.txt
@@ -2,9 +2,9 @@
 # Copied from: https://github.com/iiab/iiab-factory/blob/master/install.txt
 
 # To install Internet-in-a-Box (IIAB) 8.0 / pre-release onto Raspberry Pi OS,
-# Ubuntu 20.04+, Linux Mint 20 or Debian 11+, run this 1-line installer:
+# Ubuntu 20.04+, Linux Mint 20+ or Debian 11+, run this 1-line installer:
 #
-#                   curl iiab.io/install.txt | sudo bash
+#                     curl iiab.io/install.txt | bash
 
 # 1. WARNING: NOOBS IS *NOT* SUPPORTED, as its partitioning is very different.
 #    On a Raspberry Pi, WE RECOMMEND YOU INSTALL THE LATEST RASPBERRY PI OS:
@@ -18,19 +18,15 @@
 #    PHONES/TABLETS (WHICH REQUIRE 2.4 GHz) FROM CONNECTING TO YOUR IIAB'S
 #    INTERNAL HOTSPOT.  See: "wifi_up_down: True" in /etc/iiab/local_vars.yml
 
-# 3. Run 'sudo raspi-config' on RPi, to set LOCALISATION OPTIONS
+# 3. Run 'sudo raspi-config' on Raspberry Pi, to set LOCALISATION OPTIONS
 
 # 4. OPTIONAL: if you have slow/pricey Internet, pre-position KA Lite's
-#    mandatory 0.9 GB English Pack (en.zip) within /tmp -- you can grab a copy
-#    from https://pantry.learningequality.org/downloads/ka-lite/0.17/content/contentpacks/en.zip
+#    mandatory 0.9 GB English Pack (en.zip) within /tmp -- you can grab it from
+#    https://pantry.learningequality.org/downloads/ka-lite/0.17/content/contentpacks/en.zip
 
-# 5. WHEN YOU RUN 1-LINE INSTALLER 'curl iiab.io/install.txt | sudo bash'
-#    YOU THEN NEED TO TYPE IN YOUR PASSWORD IF ON UBUNTU/DEBIAN/ETC (for sudo)
-#    ^^^ ^^^^ ^^^^ ^^ ^^^^ ^^ ^^^^ ^^^^^^^^
+# 5. Follow on-screen instructions (TYPE 'sudo iiab' TO RESUME IF EVER NECESS!)
 
-# 6. Follow on-screen instructions (TYPE 'sudo iiab' TO RESUME IF EVER NECESS!)
-
-# 7. Within about 1-2 hours, it will announce that INTERNET-IN-A-BOX (IIAB)
+# 6. Within about 1-2 hours, it will announce that INTERNET-IN-A-BOX (IIAB)
 #    SOFTWARE INSTALL IS COMPLETE, prompting you to reboot...TO ADD CONTENT!
 
 # Thanks   For   Building   Your   Own   Library   To   Serve   One   &   All
@@ -38,8 +34,8 @@
 # DRAFT IIAB 8.0 Release Notes:
 # https://github.com/iiab/iiab/wiki/IIAB-8.0-Release-Notes
 #
-# Write to bugs @ iiab.io if you find issues, Thank You!  Special Thanks to the
-# countries+communities+volunteers who worked non-stop to bring about IIAB 8.0!
+# SPECIAL THANKS to countries + communities + volunteers who worked non-stop
+# to bring about IIAB 8.0!  https://internet-in-a-box.org/contributing.html
 #
 # IIAB Dev Team
 # http://FAQ.IIAB.IO
@@ -48,11 +44,11 @@ set -e                                   # Exit on error (avoids snowballing)
 export DEBIAN_FRONTEND=noninteractive    # Bypass (most!) interactive questions
 
 # Save script to /usr/sbin/iiab (easy resume/continue mnemonic 'sudo iiab')
-mv /usr/sbin/iiab /usr/sbin/iiab.old 2> /dev/null || true    # Overrides 'set -e'
-curl https://raw.githubusercontent.com/iiab/iiab-factory/master/iiab > /usr/sbin/iiab
-chmod 0744 /usr/sbin/iiab
+sudo mv /usr/sbin/iiab /usr/sbin/iiab.old 2> /dev/null || true    # Overrides 'set -e'
+curl https://raw.githubusercontent.com/iiab/iiab-factory/master/iiab | sudo tee /usr/sbin/iiab > /dev/null
+sudo chmod 0744 /usr/sbin/iiab
 
 # Run install script!
-/usr/sbin/iiab "$@" # Pass on all CLI params (PR #s) for easy community
-# testing.  Example: curl iiab.io/install.txt | sudo bash -s 361 2604 2607
-# As explained in /usr/sbin/iiab Section "J. Install optional PR's"
+sudo /usr/sbin/iiab "$@"    # Pass on all CLI params (PR #s) for easy
+# community testing -- SEE "Install optional PR's" in /usr/sbin/iiab
+# EXAMPLE: curl iiab.io/install.txt | bash -s 361 2604 2607

--- a/risky.txt
+++ b/risky.txt
@@ -2,9 +2,9 @@
 # Copied from: https://github.com/iiab/iiab-factory/blob/master/risky.txt
 
 # To install Internet-in-a-Box (IIAB) 8.0 / pre-release onto Raspberry Pi OS,
-# Ubuntu 20.04+, Linux Mint 20 or Debian 11+, run this 1-line installer:
+# Ubuntu 20.04+, Linux Mint 20+ or Debian 11+, run this 1-line installer:
 #
-#                    curl iiab.io/risky.txt | sudo bash
+#                      curl iiab.io/risky.txt | bash
 
 # 1. WARNING: NOOBS IS *NOT* SUPPORTED, as its partitioning is very different.
 #    On a Raspberry Pi, WE RECOMMEND YOU INSTALL THE LATEST RASPBERRY PI OS:
@@ -18,19 +18,15 @@
 #    PHONES/TABLETS (WHICH REQUIRE 2.4 GHz) FROM CONNECTING TO YOUR IIAB'S
 #    INTERNAL HOTSPOT.  See: "wifi_up_down: True" in /etc/iiab/local_vars.yml
 
-# 3. Run 'sudo raspi-config' on RPi, to set LOCALISATION OPTIONS
+# 3. Run 'sudo raspi-config' on Raspberry Pi, to set LOCALISATION OPTIONS
 
 # 4. OPTIONAL: if you have slow/pricey Internet, pre-position KA Lite's
-#    mandatory 0.9 GB English Pack (en.zip) within /tmp -- you can grab a copy
-#    from https://pantry.learningequality.org/downloads/ka-lite/0.17/content/contentpacks/en.zip
+#    mandatory 0.9 GB English Pack (en.zip) within /tmp -- you can grab it from
+#    https://pantry.learningequality.org/downloads/ka-lite/0.17/content/contentpacks/en.zip
 
-# 5. WHEN YOU RUN 1-LINE INSTALLER 'curl iiab.io/risky.txt | sudo bash'
-#    YOU THEN NEED TO TYPE IN YOUR PASSWORD IF ON UBUNTU/DEBIAN/ETC (for sudo)
-#    ^^^ ^^^^ ^^^^ ^^ ^^^^ ^^ ^^^^ ^^^^^^^^
+# 5. Follow on-screen instructions (TYPE 'sudo iiab' TO RESUME IF EVER NECESS!)
 
-# 6. Follow on-screen instructions (TYPE 'sudo iiab' TO RESUME IF EVER NECESS!)
-
-# 7. Within about 1-2 hours, it will announce that INTERNET-IN-A-BOX (IIAB)
+# 6. Within about 1-2 hours, it will announce that INTERNET-IN-A-BOX (IIAB)
 #    SOFTWARE INSTALL IS COMPLETE, prompting you to reboot...TO ADD CONTENT!
 
 # Thanks   For   Building   Your   Own   Library   To   Serve   One   &   All
@@ -38,8 +34,8 @@
 # DRAFT IIAB 8.0 Release Notes:
 # https://github.com/iiab/iiab/wiki/IIAB-8.0-Release-Notes
 #
-# Write to bugs @ iiab.io if you find issues, Thank You!  Special Thanks to the
-# countries+communities+volunteers who worked non-stop to bring about IIAB 8.0!
+# SPECIAL THANKS to countries + communities + volunteers who worked non-stop
+# to bring about IIAB 8.0!  https://internet-in-a-box.org/contributing.html
 #
 # IIAB Dev Team
 # http://FAQ.IIAB.IO
@@ -48,11 +44,11 @@ set -e                                   # Exit on error (avoids snowballing)
 export DEBIAN_FRONTEND=noninteractive    # Bypass (most!) interactive questions
 
 # Save script to /usr/sbin/iiab (easy resume/continue mnemonic 'sudo iiab')
-mv /usr/sbin/iiab /usr/sbin/iiab.old 2> /dev/null || true    # Overrides 'set -e'
-curl https://raw.githubusercontent.com/iiab/iiab-factory/master/iiab > /usr/sbin/iiab
-chmod 0744 /usr/sbin/iiab
+sudo mv /usr/sbin/iiab /usr/sbin/iiab.old 2> /dev/null || true    # Overrides 'set -e'
+curl https://raw.githubusercontent.com/iiab/iiab-factory/master/iiab | sudo tee /usr/sbin/iiab > /dev/null
+sudo chmod 0744 /usr/sbin/iiab
 
 # Run install script!
-/usr/sbin/iiab --risky "$@" # Pass on all CLI params (PR #s) for easy community
-# testing.  Example: curl iiab.io/risky.txt | sudo bash -s 361 2604 2607
-# As explained in /usr/sbin/iiab Section "J. Install optional PR's"
+sudo /usr/sbin/iiab --risky "$@"    # Pass on all CLI params (PR #s) for
+# easy community testing -- SEE "Install optional PR's" in /usr/sbin/iiab
+# EXAMPLE: curl iiab.io/install.txt | bash -s 361 2604 2607


### PR DESCRIPTION
Resolves:

- iiab/iiab#3346

...so that people who are less familiar with Linux and sudo **know** when they need to type in the password for sudo.  Almost immediately after they run this NEW/SHORTER 1-liner to install IIAB:

`curl iiab.io/install.txt | bash`

The new prompt (after this PR is merged) will typically look like this:

`[sudo] password for iiab-admin:`

This PR also refines in-line tips + explanations within all three 1-line-installer files { install.txt, fast.txt, risky.txt }.
Thanks to @pickypet for pointing out how confusing it was &mdash; to be prompted for a password WITHOUT any visual hint!

Finally: This new approach was tested with a couple very generic IIAB installs.
Broad community testing would also be great, to verify this new approach works for essentially everybody :heavy_check_mark: