### PR TITLE
Avoid 'sudo iiab' apt holdups re: "Key is stored in legacy trusted.gpg"

### DIFF
--- a/iiab
+++ b/iiab
@@ -413,8 +413,11 @@ if ! $($MFABT); then
     # echo -e "2019-07-11 TEMP WORKAROUND FOR RASPBIAN BUSTER'S testing->stable apt GLITCH...\nDetails @ https://github.com/iiab/iiab/issues/1856\n"
     # apt -y update || true    # Overrides 'set -e'
     # echo -e "\nNOW THE REAL 'apt update' WILL RUN...\n"
-    $APTPATH/apt -qq update > /tmp/apt.stdout 2> /tmp/apt.stderr || true    # Overrides 'set -e'
-    if (( $(wc -c < /tmp/apt.stderr) > 82 )); then    # apt.stderr typically contains exactly 82 characters when there are no errors, no matter the primary locale, i.e. 3-line file "\nWARNING: apt does not have a stable CLI interface. Use with caution in scripts.\n\n" ...OR... in other cases more than 82, e.g. many lines of errors when apt is busy/locked/offline/etc
+    $APTPATH/apt -qq update > /tmp/apt.stdout 2> /tmp/apt.stderr; rc=$(echo $?) || true    # Overrides 'set -e'
+    #if (( $(wc -c < /tmp/apt.stderr) > 82 )); then    # apt.stderr typically contains exactly 82 characters when there are no errors, no matter the primary locale, i.e. 3-line file "\nWARNING: apt does not have a stable CLI interface. Use with caution in scripts.\n\n" ...OR... in other cases more than 82, e.g. many lines of errors when apt is busy/locked/offline/etc
+    # 2022-10-28: BEWARE 'apt -qq update 2> /tmp/apt.stderr' would behave very differently (i.e. if STDIN isn't being redirected, then [1] /tmp/apt.stderr DOESN'T contain 82-char warning "\nWARNING: apt does not have a stable CLI interface. Use with caution in scripts.\n\n" and [2] /tmp/apt.stderr DOES contain ANSI color escape codes, which grep [BELOW] would need to scan for using https://unix.stackexchange.com/questions/324835/grep-for-an-ansi-escape-code)
+    #if grep -q '^E: ' /tmp/apt.stderr; then    # We ignore '^W: ' warnings and '^N: ' notices (per: https://unix.stackexchange.com/questions/590027/what-does-the-error-line-prefix-w-mean-like-from-apt-get-or-other-similar) to avoid 'sudo iiab' holdups arising from {MongoDB, Yarn, etc} "Key is stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg)"
+    if [[ $rc != "0" ]]; then    # apt's Return Code simpler (than both conditions above!)
         echo -e "'apt update' FAILED. VERIFY YOU'RE ONLINE and resolve all errors below:\n"
         cat /tmp/apt.stderr
         exit 1


### PR DESCRIPTION
Arising from apt installation of non-standard packages MongoDB, Yarn, etc &mdash; that have not yet modernized their insecure apt keyring approach.

SUMMARY: People who re-run `sudo iiab` expect the `apt update` portion to proceed uninterrupted!  However: in recent months this is no longer happening, as a result of numerous old apt packages using the deprecated approach, leading to warnings like the following:

```
root@box:~# apt update
...
W: https://dl.yarnpkg.com/debian/dists/stable/InRelease: Key is stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg), see the DEPRECATION section in apt-key(8) for details.
W: https://repo.mongodb.org/apt/ubuntu/dists/focal/mongodb-org/6.0/Release.gpg: Key is stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg), see the DEPRECATION section in apt-key(8) for details.
```

Conclusion: This PR simplifies, by handling apt's return code directly, instead of interpreting/parsing apt's STDERR output.

PS Here's just one more example (Kolibri) of an apt package that is working to abide by the new Debian / apt standard:

- PR #3356