### PR TITLE
Warn users to remember "sudo iiab" command

### DIFF
--- a/iiab
+++ b/iiab
@@ -410,6 +410,8 @@ echo -e "\n\n ██████████████████████
 echo -e " ██                                                                          ██"
 echo -e " ██  RUN 'sudo iiab' IF THIS INSTALL SCRIPT EVER FAILS, TO TRY TO CONTINUE!  ██"
 echo -e " ██                                                                          ██"
+echo -e " ██  (Remember this command. This message will disappear from your screen.)  ██"
+echo -e " ██                                                                          ██"
 echo -e " ██████████████████████████████████████████████████████████████████████████████"
 
 if ! $($MFABT); then


### PR DESCRIPTION
An idea I had just from using it. Not something I'm adamant about. If it doesn't strike you as useful I'm happy to forget about it.

This warning is kind of obvious and yet somehow it didn't occur to me. "Wait what was that command again?" I should have written it down or something.