### PR TITLE
Expand RasPiOS swap very early on during IIAB installs (see 'man swap.conf') — and avoid reboot if just setting `Storage=persistent`

### DIFF
--- a/iiab
+++ b/iiab
@@ -415,7 +415,7 @@ fi
 # https://github.com/iiab/iiab-factory/pull/251
 # https://github.com/iiab/iiab-factory/pull/252
 if [ -f /etc/rpi-issue ] && [ ! -f /usr/lib/systemd/journald.conf.d/90-iiab-persistent-storage.conf ]; then
-    echo -e "\nSystemd logging across RasPiOS reboots being enabled..."
+    echo -e "\nEnabling systemd logging across Raspberry Pi OS reboots..."
     cat << EOF > /usr/lib/systemd/journald.conf.d/90-iiab-persistent-storage.conf
 [Journal]
 Storage=persistent

--- a/iiab
+++ b/iiab
@@ -412,13 +412,15 @@ fi
 # rpi-systemd-config systemd/journald.conf JRNL_STRG Journal::Storage
 # https://github.com/iiab/iiab/issues/4047
 # https://github.com/raspberrypi/bookworm-feedback/issues/415
+# https://github.com/iiab/iiab-factory/pull/251
+# https://github.com/iiab/iiab-factory/pull/252
 if [ -f /etc/rpi-issue ] && [ ! -f /usr/lib/systemd/journald.conf.d/90-iiab-persistent-storage.conf ]; then
-    echo -e "\n\nSystemd logging across RasPiOS reboots being enabled, \e[1mwhich may force a reboot...\e[0m\n"
+    echo -e "\nSystemd logging across RasPiOS reboots being enabled...\n"
     cat << EOF > /usr/lib/systemd/journald.conf.d/90-iiab-persistent-storage.conf
 [Journal]
 Storage=persistent
 EOF
-    reboot_needed=true
+    systemctl restart systemd-journald
 fi
 
 # E. RasPiOS 13 Trixie apt package 'rpi-swap' mandates a reboot to expand swap
@@ -427,7 +429,7 @@ fi
 # https://github.com/iiab/iiab/pull/4094
 # https://github.com/iiab/iiab/issues/4108
 if [ -f /etc/rpi/swap.conf ] && [ ! -f /etc/rpi/swap.conf.d/90-iiab-swap.conf ]; then
-    echo -e "\n\nExpanding RasPiOS swap (see 'man swap.conf'), \e[1mwhich may force a reboot...\e[0m\n"
+    echo -e "\nExpanding RasPiOS swap (see 'man swap.conf'), \e[1mwhich may force a reboot...\e[0m\n"
     PI_SWAP_FILE_SIZE=$(iiab_var_value pi_swap_file_size)
     mkdir -p /etc/rpi/swap.conf.d/
     cat << EOF > /etc/rpi/swap.conf.d/90-iiab-swap.conf

--- a/iiab
+++ b/iiab
@@ -47,6 +47,7 @@ export DEBIAN_FRONTEND=noninteractive    # Bypass (most!) interactive questions
 
 FLAGDIR=/etc/iiab/install-flags
 APTPATH=/usr/bin    # Avoids problematic /usr/local/bin/apt on Linux Mint
+reboot_needed=false
 
 FAST=false    # YOUR OWN RISK: Fewer security & user education prompts.
 MFABT=false   # As above BUT bypasses editing of local_vars.yml + apt updates.
@@ -407,19 +408,39 @@ fi
 # D. RasPiOS prevents things like 'journalctl --list-boots' since May 2025, so
 # we restore systemd logging across boots, overriding 'Storage=volatile' that
 # they set in /usr/lib/systemd/journald.conf.d/40-rpi-volatile-storage.conf
+# To see your current setting, run:
+# rpi-systemd-config systemd/journald.conf JRNL_STRG Journal::Storage
 # https://github.com/iiab/iiab/issues/4047
 # https://github.com/raspberrypi/bookworm-feedback/issues/415
-persistent_just_enabled=false
 if [ -f /etc/rpi-issue ] && [ ! -f /usr/lib/systemd/journald.conf.d/90-iiab-persistent-storage.conf ]; then
     echo -e "\n\nSystemd logging across RasPiOS reboots being enabled, \e[1mwhich may force a reboot...\e[0m\n"
     cat << EOF > /usr/lib/systemd/journald.conf.d/90-iiab-persistent-storage.conf
 [Journal]
 Storage=persistent
 EOF
-    persistent_just_enabled=true
+    reboot_needed=true
 fi
 
-# E. Mandate OS SECURITY/UPDATES if 'apt update' has any (THEN REBOOT, AS NEC)
+# E. RasPiOS 13 Trixie apt package 'rpi-swap' mandates a reboot to expand swap
+# (at least according to 'man swap.conf' man page, as of Oct 2025) -- to allow
+# IIAB software installs to proceed on low-RAM machines, e.g. RPi Zero 2 W:
+# https://github.com/iiab/iiab/pull/4094
+# https://github.com/iiab/iiab/issues/4108
+if [ -f /etc/rpi/swap.conf ] && [ ! -f /etc/rpi/swap.conf.d/90-iiab-swap.conf ]; then
+    echo -e "\n\nExpanding RasPiOS swap (see 'man swap.conf'), \e[1mwhich may force a reboot...\e[0m\n"
+    PI_SWAP_FILE_SIZE=$(iiab_var_value pi_swap_file_size)
+    mkdir -p /etc/rpi/swap.conf.d/
+    cat << EOF > /etc/rpi/swap.conf.d/90-iiab-swap.conf
+[Main]
+Mechanism=swapfile
+
+[File]
+FixedSizeMiB=$PI_SWAP_FILE_SIZE
+EOF
+    reboot_needed=true
+fi
+
+# F. Mandate OS SECURITY/UPDATES if 'apt update' has any (THEN REBOOT, AS NEC)
 # Educate implementer while waiting for 'apt update'
 echo -e "\n\n ██████████████████████████████████████████████████████████████████████████████"
 echo -e " ██                                                                          ██"
@@ -469,7 +490,7 @@ if ! $($MFABT); then
     bootDirLastModFile=$(date +%s -r "/boot/$(ls -t /boot | head -1)") # 1970-01-01
     # Works w/o RTC (real-time clock, i.e. battery) because:
     # Both 'apt' installs to /boot and IIAB installs require Internet (e.g. NTP).
-    if (( bootupTime < bootDirLastModFile )) || $($persistent_just_enabled); then
+    if (( bootupTime < bootDirLastModFile )) || $($reboot_needed); then
         reboot
         exit 0    # Nec to avoid bogus continuation & misleading output below
     fi
@@ -479,20 +500,20 @@ fi
 ################### MAIN INTERACTIVE STUFF (ABOVE) DONE!!! ###################
 ##############################################################################
 
-# F. If microSD, lower reserve disk space from ~5% to 2%
+# G. If microSD, lower reserve disk space from ~5% to 2%
 # if [ -f /proc/device-tree/model ] && grep -qi raspberry /proc/device-tree/model; then
 if [ -e /dev/mmcblk0p2 ]; then
     echo -e "\n\nFound microSD card /dev/mmcblk0p2: Lower its reserve disk space from ~5% to 2%\n"
     tune2fs -m 2 /dev/mmcblk0p2
 fi
 
-# G. For a smoother + tighter UX in above interactive portion
+# H. For a smoother + tighter UX in above interactive portion
 if ! $($clones_and_pulls_done); then
     clone-repos
     pull-prs
 fi
 
-# H. Install Ansible + 2 IIAB repos
+# I. Install Ansible + 2 IIAB repos
 echo -e "\n\nINSTALL ANSIBLE + CORE IIAB SOFTWARE + ADMIN CONSOLE / CONTENT PACK MENUS...\n"
 
 if [ -f $FLAGDIR/iiab-ansible-complete ]; then
@@ -548,7 +569,7 @@ else
     systemctl start iiab-cmdsrv || true    # Overrides 'set -e'
 fi
 
-# I. KA Lite prep
+# J. KA Lite prep
 if [ -d /library/ka-lite ]; then
     echo -e "\n\nKA LITE REQUIRES 2 THINGS...\n"
 
@@ -588,7 +609,7 @@ fi
 # kalite manage retrievecontentpack download en
 # OLD WAY ABOVE - fails w/ sev ISPs per https://github.com/iiab/iiab/issues/871
 
-# J. Start BitTorrent downloads, e.g. if /etc/iiab/local_vars.yml requested any
+# K. Start BitTorrent downloads, e.g. if /etc/iiab/local_vars.yml requested any
 if $(systemctl -q is-active transmission-daemon) && ! $(ischroot -t); then
     echo -e "\n\nSTARTING BITTORRENT DOWNLOAD(S) for KA Lite...Please Monitor: http://box:9091\n"
     transmission-remote -n Admin:changeme -t all --start
@@ -596,7 +617,7 @@ fi
 
 touch $FLAGDIR/iiab-complete
 
-# K. Educate Implementers prior to rebooting!
+# L. Educate Implementers prior to rebooting!
 echo -e "\n\n         ┌───────────────────────────────────────────────────────────┐"
 echo -e "         │                                                           │"
 echo -e "         │   INTERNET-IN-A-BOX (IIAB) SOFTWARE INSTALL IS COMPLETE   │"

--- a/iiab
+++ b/iiab
@@ -308,7 +308,7 @@ if [ -f /etc/iiab/local_vars.yml ]; then
 
     echo -e "   🚂 🚃 🚄 🚅 🚆 🚇 🚈 🚉 🚊 🚋 🚌 🚍 🚎 🚏 🚐 🚑 🚒 🚚 🚛 🚜 🚞 🚟 🚠 🚡 🚲\n"
 
-    echo -e "                     Google 'local_vars.yml' to learn more!"
+    echo -e "                     Google 'local_vars.yml' to learn more!\n"
 else
     echo -e "\n\nInstalling Internet-in-a-Box requires /etc/iiab/local_vars.yml\n"
 
@@ -323,7 +323,7 @@ else
 
     echo -n "Please press a key — 1, 2, 3 or m: "
     read -n 1 -r local_vars_size < /dev/tty
-    echo; echo
+    echo
     case $local_vars_size in
         0)
             local_vars_src_file=local_vars_unittest.yml
@@ -415,7 +415,7 @@ fi
 # https://github.com/iiab/iiab-factory/pull/251
 # https://github.com/iiab/iiab-factory/pull/252
 if [ -f /etc/rpi-issue ] && [ ! -f /usr/lib/systemd/journald.conf.d/90-iiab-persistent-storage.conf ]; then
-    echo -e "\nSystemd logging across RasPiOS reboots being enabled...\n"
+    echo -e "\nSystemd logging across RasPiOS reboots being enabled..."
     cat << EOF > /usr/lib/systemd/journald.conf.d/90-iiab-persistent-storage.conf
 [Journal]
 Storage=persistent
@@ -429,7 +429,7 @@ fi
 # https://github.com/iiab/iiab/pull/4094
 # https://github.com/iiab/iiab/issues/4108
 if [ -f /etc/rpi/swap.conf ] && [ ! -f /etc/rpi/swap.conf.d/90-iiab-swap.conf ]; then
-    echo -e "\nExpanding RasPiOS swap (see 'man swap.conf'), \e[1mwhich may force a reboot...\e[0m\n"
+    echo -e "\nExpanding RasPiOS swap (see 'man swap.conf') \e[1mwhich may force a reboot...\e[0m"
     PI_SWAP_FILE_SIZE=$(iiab_var_value pi_swap_file_size)
     mkdir -p /etc/rpi/swap.conf.d/
     cat << EOF > /etc/rpi/swap.conf.d/90-iiab-swap.conf


### PR DESCRIPTION
Let's give this a shot.

As outlined here...

- https://github.com/iiab/iiab/issues/4108#issuecomment-3374310925

Tested on Zero 2 W.

A companion "cleanup PR" will follow [iiab/iiab#4112], within repo iiab/iiab.

Building on:

- PR iiab/iiab#4094
- PR #251